### PR TITLE
deprecated api

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Selenium-Remote-Driver
 
+07/26/11 - PM
+
+Removed WebElement::get_value: has been removed from WebDriver API
+Marked as deprecated: WebElement::set_selected and WebElement::toggle
+
 07/21/11 - PM
 
 Fixed bug in Commands.pm: definition of setImplicitWaitTimeout

--- a/lib/Selenium/Remote/WebElement.pm
+++ b/lib/Selenium/Remote/WebElement.pm
@@ -56,25 +56,6 @@ sub click {
     return $self->_execute_command($res);
 }
 
-=head2 get_value
-
- Description:
-    Query for the value of an element, as determined by its value attribute.
-
- Output:
-    {STRING | NULL} The element's value, or null if it does'nt have a value attribute.
-
- Usage:
-    $elem->get_value();
-
-=cut
-
-sub get_value {
-    my ($self) = @_;
-    my $res = { 'command' => 'getElementValue', 'id' => $self->{id} };
-    return $self->_execute_command($res);
-}
-
 =head2 submit
 
  Description:
@@ -144,6 +125,8 @@ sub is_selected {
  Usage:
     $elem->set_selected();
 
+ Note: DEPRECATED -- use click instead
+
 =cut
 
 sub set_selected {
@@ -163,6 +146,8 @@ sub set_selected {
 
  Usage:
     $elem->toggle();
+
+ Note: DEPRECATED -- use click instead
 
 =cut
 


### PR DESCRIPTION
Removed WebElement::get_value: has been removed from WebDriver API
Marked as deprecated: WebElement::set_selected and WebElement::toggle
