### PR TITLE
This patch is to make it work with Grid

### DIFF
--- a/lib/Selenium/Remote/RemoteConnection.pm
+++ b/lib/Selenium/Remote/RemoteConnection.pm
@@ -21,13 +21,6 @@ sub new {
                  port               => $port,
     };
     bless $self, $class or die "Can't bless $class: $!";
-    my $status = eval {$self->request('GET','status');};
-    croak "Could not connect to SeleniumWebDriver" if($@);
-    if($status->{cmd_status} eq 'OK') {
-      return $self;
-    } else {
-      croak "Selenium server did not return proper status";
-    }
 }
 
 # This request method is tailored for Selenium RC server


### PR DESCRIPTION
I've identified why it doesn't work with the grid, and that's because when instantiating the RemoteConnection object it checks http://$selenium_server:$port/wd/hub/status and that only works in a non-grid environment. Just removing that make this class to work with selenium Grid.

Cheers,
Mariano
