### PR TITLE
Fix for get_title in IDE

### DIFF
--- a/ide-plugin.js
+++ b/ide-plugin.js
@@ -327,7 +327,7 @@ WDAPI.Driver.prototype.get = function(url) {
 };
 
 WDAPI.Driver.prototype.getTitle = function() {
-  return this.ref + "->title";
+  return this.ref + "->get_title";
 };
 
 WDAPI.Driver.prototype.refresh = function() {


### PR DESCRIPTION
Hey guys,

I noticed in the IDE that get_title was printing just title before.  I went ahead and committed a fix and ask that you now pull it in.

Thanks.
