### PR TITLE
Provide a working default proxyType value in Selenium::Remote::Driver::new() when no proxy details are passed

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -214,6 +214,8 @@ sub new {
             }
         }
         $self->{proxy} = $args{proxy};
+    } else {
+        $self->{proxy} = { proxyType => 'direct' };
     }
 
     # Connect to remote server & establish a new session


### PR DESCRIPTION
This fixes the session creation failure I've been seeing on OS X with Chrome version 20.

For what it's worth, Firefox has been working consistently. Some time in the past few months, though, I've been neglecting Chrome. Tried to load it up yesterday and the client dies with "Could not create new session". Here's the output from Server 2.23.1 when I try to create a new session:

```
14:41:46.284 INFO - Executing: org.openqa.selenium.remote.server.handler.Status@11e7c5cb at URL: /status)
14:41:46.292 INFO - Done: /status
14:41:46.308 INFO - Executing: [new session: {platform=MAC, acceptSslCerts=true, javascriptEnabled=true, browserName=chrome, proxy=null, version=}] at URL: /session)
Started ChromeDriver
port=48086
version=20.0.1133.0
log=/Users/jherm/Downloads/chromedriver.log
objc[13165]: Object 0x7aa5d940 of class NSPathStore2 autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
objc[13165]: Object 0x7aa5d9e0 of class NSPathStore2 autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
objc[13165]: Object 0x7aa5dac0 of class NSConcreteData autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
objc[13165]: Object 0x7aa5de80 of class __NSCFString autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
objc[13165]: Object 0x7aa5da90 of class NSBundle autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
14:41:47.249 WARN - Exception thrown
java.util.concurrent.ExecutionException: org.openqa.selenium.WebDriverException: java.lang.reflect.InvocationTargetException
Build info: version: '2.23.1', revision: '17143', time: '2012-06-08 18:59:04'
System info: os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.8', java.version: '1.6.0_31'
Driver info: driver.version: unknown
    at java.util.concurrent.FutureTask$Sync.innerGet(FutureTask.java:222)
    at java.util.concurrent.FutureTask.get(FutureTask.java:83)
    at org.openqa.selenium.remote.server.DefaultSession.execute(DefaultSession.java:157)
    at org.openqa.selenium.remote.server.DefaultSession.<init>(DefaultSession.java:111)
    at org.openqa.selenium.remote.server.DefaultSession.createSession(DefaultSession.java:88)
    at org.openqa.selenium.remote.server.DefaultDriverSessions.newSession(DefaultDriverSessions.java:91)
    at org.openqa.selenium.remote.server.handler.NewSession.handle(NewSession.java:61)
    at org.openqa.selenium.remote.server.rest.ResultConfig.handle(ResultConfig.java:200)
    at org.openqa.selenium.remote.server.JsonHttpRemoteConfig.handleRequest(JsonHttpRemoteConfig.java:190)
    at org.openqa.selenium.remote.server.DriverServlet.handleRequest(DriverServlet.java:201)
    at org.openqa.selenium.remote.server.DriverServlet.doPost(DriverServlet.java:167)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
    at org.openqa.selenium.remote.server.DriverServlet.service(DriverServlet.java:139)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
    at org.openqa.jetty.jetty.servlet.ServletHolder.handle(ServletHolder.java:428)
    at org.openqa.jetty.jetty.servlet.ServletHandler.dispatch(ServletHandler.java:677)
    at org.openqa.jetty.jetty.servlet.ServletHandler.handle(ServletHandler.java:568)
    at org.openqa.jetty.http.HttpContext.handle(HttpContext.java:1526)
    at org.openqa.jetty.http.HttpContext.handle(HttpContext.java:1479)
    at org.openqa.jetty.http.HttpServer.service(HttpServer.java:914)
    at org.openqa.jetty.http.HttpConnection.service(HttpConnection.java:820)
    at org.openqa.jetty.http.HttpConnection.handleNext(HttpConnection.java:986)
    at org.openqa.jetty.http.HttpConnection.handle(HttpConnection.java:837)
    at org.openqa.jetty.http.SocketListener.handleConnection(SocketListener.java:243)
    at org.openqa.jetty.util.ThreadedServer.handle(ThreadedServer.java:357)
    at org.openqa.jetty.util.ThreadPool$PoolThread.run(ThreadPool.java:534)
Caused by: org.openqa.selenium.WebDriverException: java.lang.reflect.InvocationTargetException
Build info: version: '2.23.1', revision: '17143', time: '2012-06-08 18:59:04'
System info: os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.8', java.version: '1.6.0_31'
Driver info: driver.version: unknown
    at org.openqa.selenium.remote.server.DefaultDriverFactory.callConstructor(DefaultDriverFactory.java:67)
    at org.openqa.selenium.remote.server.DefaultDriverFactory.newInstance(DefaultDriverFactory.java:51)
    at org.openqa.selenium.remote.server.DefaultSession$BrowserCreator.call(DefaultSession.java:196)
    at org.openqa.selenium.remote.server.DefaultSession$BrowserCreator.call(DefaultSession.java:1)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at org.openqa.selenium.remote.server.DefaultSession$1.run(DefaultSession.java:150)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)
Caused by: java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:39)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:513)
    at org.openqa.selenium.remote.server.DefaultDriverFactory.callConstructor(DefaultDriverFactory.java:57)
    ... 9 more
Caused by: org.openqa.selenium.WebDriverException: proxy must be of type dictionary, not null. Received: null
 (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 652 milliseconds
Build info: version: '2.23.1', revision: '17143', time: '2012-06-08 18:59:04'
System info: os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.8', java.version: '1.6.0_31'
Driver info: driver.version: ChromeDriver
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:39)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:513)
    at org.openqa.selenium.remote.ErrorHandler.createThrowable(ErrorHandler.java:188)
    at org.openqa.selenium.remote.ErrorHandler.throwIfResponseFailed(ErrorHandler.java:145)
    at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:458)
    at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:139)
    at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:94)
    at org.openqa.selenium.chrome.ChromeDriver.<init>(ChromeDriver.java:154)
    at org.openqa.selenium.chrome.ChromeDriver.<init>(ChromeDriver.java:131)
    ... 14 more
14:41:47.257 WARN - Exception: proxy must be of type dictionary, not null. Received: null
 (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 652 milliseconds
Build info: version: '2.23.1', revision: '17143', time: '2012-06-08 18:59:04'
System info: os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.8', java.version: '1.6.0_31'
Driver info: driver.version: ChromeDriver
```

and Chrome never gets launched. It's at the standard path and all.

With this change, I can just tell the client I want Chrome and everything starts up swimmingly.
