### PR TITLE
Fix: passing '0' for secure option in add_cookie incorrectly creates secure cookie

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1349,7 +1349,7 @@ sub add_cookie {
     my $res        = { 'command' => 'addCookie' };
     my $json_false = JSON::false;
     my $json_true  = JSON::true;
-    $secure = ( defined $secure ) ? $json_true : $json_false;
+    $secure = ( defined $secure && $secure ) ? $json_true : $json_false;
 
     my $params = {
         'cookie' => {

--- a/t/01-driver.t
+++ b/t/01-driver.t
@@ -11,7 +11,7 @@ BEGIN {
       BAIL_OUT ("Couldn't load Driver");
       exit;
    }
-   
+
    if (defined $ENV{'WD_MOCKING_RECORD'} && ($ENV{'WD_MOCKING_RECORD'}==1))
    {
       use t::lib::MockSeleniumWebDriver;
@@ -119,6 +119,7 @@ COOKIES: {
             pass('Adding cookie foo...');
             $ret = $driver->get_all_cookies();
             is(@{$ret}, 1, 'foo cookie added.');
+            is($ret->[0]{'secure'}, "false", 'foo cookie insecure.');
             $ret = $driver->delete_cookie_named('foo');
             pass('Deleting cookie foo...');
             $ret = $driver->get_all_cookies();
@@ -245,4 +246,3 @@ elsif ($record)
 }
 
 done_testing;
-


### PR DESCRIPTION
Previously, passing 0 for the 'secure' option in add_cookie would create a cookie that was secure. I was expecting that passing 1 or anything true would create a secure cookie, but that 0 would create an insecure cookie. Now, the cookie will only be secure if the value passed in for secure evaluates to true. Also added an associated test to guarantee that the cookie created with '0' for secure is in fact insecure.
