### PR TITLE
find_elements return epmty list

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1526,7 +1526,7 @@ sub find_elements {
             die $@;
           }
         }
-        my $elem_obj_arr;
+        my $elem_obj_arr = [];
         my $i = 0;
         foreach (@$ret_data) {
             $elem_obj_arr->[$i] = new Selenium::Remote::WebElement($_->{ELEMENT}, $self);


### PR DESCRIPTION
Hey,

I am tried to use "find_elements" method for check if some element exits on the page, but it falls if elements not found, so I added empty array that should be returned by default.
