### PR TITLE
Small codechanges regarding default finder and find_elements

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -117,6 +117,8 @@ created when you use the find_* methods.
         'accept_ssl_certs' - <boolean> - whether SSL certs should be accepted, default is true.
         'auto_close' - <boolean> - whether driver should end session on remote
                                    server on close.
+        'default_finder' - <string> - choose default finder used for find_element*
+                                      {class|class_name|css|id|link|link_text|name|partial_link_text|tag_name|xpath}
         'extra_capabilities' - HASH of extra capabilities
         'proxy' - HASH - Proxy configuration with the following keys:
             'proxyType' - <string> - REQUIRED, Possible values are:
@@ -161,6 +163,8 @@ created when you use the find_* methods.
                                               );
     or
     my $driver = Selenium::Remote::Driver->new('proxy' => {'proxyType' => 'manual', 'httpProxy' => 'myproxy.com:1234'});
+    or
+    my $driver = Selenium::Remote::Driver->new('default_finder' => 'css');
 
 =cut
 
@@ -170,16 +174,17 @@ sub new {
 
     # Set the defaults if user doesn't send any
     my $self = {
-        remote_server_addr => delete $args{remote_server_addr} || 'localhost',
-        browser_name       => delete $args{browser_name}       || 'firefox',
-        platform           => delete $args{platform}           || 'ANY',
-        port               => delete $args{port}               || '4444',
-        version            => delete $args{version}            || '',
+        remote_server_addr => delete $args{remote_server_addr}        || 'localhost',
+        browser_name       => delete $args{browser_name}              || 'firefox',
+        platform           => delete $args{platform}                  || 'ANY',
+        port               => delete $args{port}                      || '4444',
+        version            => delete $args{version}                   || '',
+        default_finder     => FINDERS->{delete $args{default_finder}} || 'xpath',
         session_id         => undef,
         remote_conn        => undef,
         commands           => $ress,
         auto_close         => 1, # by default we will close remote session on DESTROY
-        pid                => $$,
+        pid                => $$
     };
     bless $self, $class or die "Can't bless $class: $!";
 
@@ -1443,7 +1448,7 @@ sub get_page_source {
         STRING - Locator scheme to use to search the element, available schemes:
                  {class, class_name, css, id, link, link_text, partial_link_text,
                   tag_name, name, xpath}
-                 Defaults to 'xpath'.
+                 Defaults to 'xpath' if not configured global during instantiation.
 
  Output:
     Selenium::Remote::WebElement - WebElement Object
@@ -1458,7 +1463,7 @@ sub find_element {
     if ( not defined $query ) {
         return 'Search string to find element not provided.';
     }
-    my $using = ( defined $method ) ? FINDERS->{$method} : 'xpath';
+    my $using = ( defined $method ) ? FINDERS->{$method} : $self->{default_finder};
     if (defined $using) {
         my $res = { 'command' => 'findElement' };
         my $params = { 'using' => $using, 'value' => $query };
@@ -1495,7 +1500,7 @@ sub find_element {
         STRING - Locator scheme to use to search the element, available schemes:
                  {class, class_name, css, id, link, link_text, partial_link_text,
                   tag_name, name, xpath}
-                 Defaults to 'xpath'.
+                 Defaults to 'xpath' if not configured global during instantiation.
 
  Output:
     ARRAY of Selenium::Remote::WebElement - Array of WebElement Objects
@@ -1510,7 +1515,9 @@ sub find_elements {
     if ( not defined $query ) {
         return 'Search string to find element not provided.';
     }
-    my $using = ( defined $method ) ? FINDERS->{$method} : 'xpath';
+
+    my $using = ( defined $method ) ? FINDERS->{$method} : $self->{default_finder};
+
     if (defined $using) {
         my $res = { 'command' => 'findElements' };
         my $params = { 'using' => $using, 'value' => $query };
@@ -1526,13 +1533,11 @@ sub find_elements {
             die $@;
           }
         }
-        my $elem_obj_arr;
-        my $i = 0;
+        my @elem_obj_arr = ();
         foreach (@$ret_data) {
-            $elem_obj_arr->[$i] = new Selenium::Remote::WebElement($_->{ELEMENT}, $self);
-            $i++;
+          push(@elem_obj_arr, new Selenium::Remote::WebElement($_->{ELEMENT}, $self));
         }
-        return wantarray?@{$elem_obj_arr}:$elem_obj_arr;
+        return @elem_obj_arr;
     }
     else {
         croak "Bad method, expected - class, class_name, css, id, link,
@@ -1559,7 +1564,7 @@ sub find_elements {
         STRING - Locator scheme to use to search the element, available schemes:
                  {class, class_name, css, id, link, link_text, partial_link_text,
                   tag_name, name, xpath}
-                 Defaults to 'xpath'.
+                 Defaults to 'xpath' if not configured global during instantiation.
 
  Output:
     Selenium::Remote::WebElement - WebElement Object
@@ -1576,7 +1581,7 @@ sub find_child_element {
     if ( ( not defined $elem ) || ( not defined $query ) ) {
         return "Missing parameters";
     }
-    my $using = ( defined $method ) ? $method : 'xpath';
+    my $using = ( defined $method ) ? $method : $self->{default_finder};
     if (exists FINDERS->{$using}) {
         my $res = { 'command' => 'findChildElement', 'id' => $elem->{id} };
         my $params = { 'using' => FINDERS->{$using}, 'value' => $query };
@@ -1616,7 +1621,7 @@ sub find_child_element {
         STRING - Locator scheme to use to search the element, available schemes:
                  {class, class_name, css, id, link, link_text, partial_link_text,
                   tag_name, name, xpath}
-                 Defaults to 'xpath'.
+                 Defaults to 'xpath' if not configured global during instantiation.
 
  Output:
     ARRAY of Selenium::Remote::WebElement - Array of WebElement Objects.
@@ -1632,7 +1637,7 @@ sub find_child_elements {
     if ( ( not defined $elem ) || ( not defined $query ) ) {
         return "Missing parameters";
     }
-    my $using = ( defined $method ) ? $method : 'xpath';
+    my $using = ( defined $method ) ? $method : $self->{default_finder};
     if (exists FINDERS->{$using}) {
         my $res = { 'command' => 'findChildElements', 'id' => $elem->{id} };
         my $params = { 'using' => FINDERS->{$using}, 'value' => $query };


### PR DESCRIPTION
I created a small patch wich allows you to change the default finder from xpath to something different like css (in my case). 
The second change is about always returning an array in the find elements sub to be possible to use it in array context like  "foreach($self->driver->find_elements('#tab-panel button')) {", now it will always return an array (if nothing found an empty one).
I adjusted the POD and rerun all unit tests, so please take a look and make suggestions if you disagree with some changes.
