### PR TITLE
Update Driver.pm

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1528,7 +1528,7 @@ sub find_elements {
             die $@;
           }
         }
-        my $elem_obj_arr;
+        my $elem_obj_arr = [];
         my $i = 0;
         foreach (@$ret_data) {
             $elem_obj_arr->[$i] = new Selenium::Remote::WebElement($_->{ELEMENT}, $self);


### PR DESCRIPTION
Initialize $elem_obj_arr in find_elements so that searching for a non-existent element in list context doesn't cause an dereference error.
