### PR TITLE
fix #20; WebElement::hover calls Driver::move_to

### DIFF
--- a/lib/Selenium/Remote/Commands.pm
+++ b/lib/Selenium/Remote/Commands.pm
@@ -241,10 +241,6 @@ sub new {
             'method' => 'GET',
             'url' => "session/:sessionId/element/:id/css/:propertyName"
         },
-        'hoverOverElement' => {
-               'method' => 'POST',
-               'url' => "session/:sessionId/element/:id/hover"
-        },
         'mouseMoveToLocation' => {
                'method' => 'POST',
                'url' => "session/:sessionId/moveto"

--- a/lib/Selenium/Remote/WebElement.pm
+++ b/lib/Selenium/Remote/WebElement.pm
@@ -431,21 +431,6 @@ sub get_css_attribute {
     return $self->_execute_command($res);
 }
 
-=head2 hover
-
- Description:
-    Move the mouse over an element.
-
- Usage:
-    $elem->hover();
-
-=cut
-
-sub hover {
-    my ($self) = @_;
-    return $self->{driver}->move_to( element => $self );
-}
-
 =head2 describe
 
  Description:


### PR DESCRIPTION
WebElement.pm includes a `hover` method which consistently errors out with:

```
Error while executing command: Server returned error code 404 and no data at C:/strawberry/perl/site/lib/Selenium/Remote/WebElement.pm line 46.
```

Discussion at #20 suggested calling Driver.pm's `move_to` instead. This pull request makes `hover` call `move_to`.

Apologies if this is malformed at all; I'm newish and rusty. Feedback would be appreciated if you have any!
