### PR TITLE
Add auto_close option to new()

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -193,7 +193,7 @@ sub new {
         session_id         => undef,
         remote_conn        => undef,
         commands           => $ress,
-        auto_close         => 1, # by default we will close remote session on DESTROY
+        auto_close         => delete $args{auto_close}                || 1, # by default we will close remote session on DESTROY
         pid                => $$
     };
     bless $self, $class or die "Can't bless $class: $!";


### PR DESCRIPTION
Hi,
I don't know whether it was on purpose that the auto_close setting was not set by the new method. I added this because I need it in my scripts. Maybe more people are missing this.
