### PR TITLE
Test::Selenium::Remote::Role::DoesTesting - better description for send_keys_ok()

### DIFF
--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -54,7 +54,8 @@ sub _check_ok {
     };
 
     my $default_test_name = $method;
-    $default_test_name .= join(" ", @r_args) if $num_of_args > 0;
+    $default_test_name .= "'" . join("' ", @r_args) . "'"
+        if $num_of_args > 0;
 
     my $test_name = pop @args // $default_test_name;
     return $self->ok( $rv, $test_name);


### PR DESCRIPTION
currently send_keys_ok() has a test description equal to 'send_keys'.  So my tests look like this:

```
ok 1 - send_keys
ok 2 - send_keys
ok 3 - send_keys
```

This pr will change it to look like:

```
ok 1 - send_keys 'FirstName'
ok 2 - send_keys 'LastName'
ok 3 - send_keys '(123) 123-1234'
```
