### PR TITLE
Attempted fix for (github) issue #128 / unexported encode_base64:

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2152,7 +2152,7 @@ sub upload_file {
     require MIME::Base64;
 
     my $params = {
-        file => encode_base64($string)          # base64-encoded string
+        file => MIME::Base64::encode_base64($string)          # base64-encoded string
     };
     return $self->_execute_command( $res, $params );
 }


### PR DESCRIPTION
Attempted fix for (github) issue #128 / un-exported encode_base64:

When I attempt to use

$driver->upload_file( $foo );

I get:

Undefined subroutine &Selenium::Remote::Driver::encode_base64
