### PR TITLE
content_like should not throw away description

### DIFF
--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -318,12 +318,12 @@ sub content_like {
     my $content = $self->get_page_source();
 
     if ( not ref $regex eq 'ARRAY' ) {
-        my $desc = qq{Content is like "$regex"} if ( not defined $desc );
+        $desc = qq{Content is like "$regex"} if ( not defined $desc );
         return like_string( $content, $regex, $desc );
     }
     elsif ( ref $regex eq 'ARRAY' ) {
         for my $re (@$regex) {
-            my $desc = qq{Content is like "$re"} if ( not defined $desc );
+            $desc = qq{Content is like "$re"} if ( not defined $desc );
             like_string( $content, $re, $desc );
         }
     }

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -99,5 +99,27 @@ my $element = Test::Selenium::Remote::WebElement->new(
 
 }
 
+# content_like
+{
+    $successful_driver->mock( 'get_page_source', sub { 'this output matches regex' } );
+    check_tests(
+        sub {
+            my $rc = $successful_driver->content_like( qr/matches/,
+                'content_like works' );
+            is( $rc, 1, 'returns true' );
+        },
+        [   {   ok   => 1,
+                name => "content_like works",
+                diag => "",
+            },
+            {   ok   => 1,
+                name => "returns true",
+                diag => "",
+            },
+        ]
+    );
+
+}
+
 
 done_testing();


### PR DESCRIPTION
There's a little bug in content_like which causes the user-entered description to be lost.

For example:

`$driver->content_like( qr/PotatoSalad/, "There is some potato salad in there" );`

will report without a message:
`ok 1`
