### PR TITLE
has_javascript compatibility with JSON::XS 3.01+

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1195,7 +1195,7 @@ sub refresh {
 
 sub has_javascript {
     my $self = shift;
-    return $self->javascript == JSON::true;
+    return int($self->javascript);
 }
 
 =head2 execute_async_script


### PR DESCRIPTION
has_javascript { return $self->javascript == JSON::true; }

but we can't use == in JSON::XS 3.01 or JSON::PP (not overloaded properly)
should always eval to int (according to author)
