### PR TITLE
Error in 'make test':  #   at t/01-driver.t line 259.

### DIFF
--- a/t/01-driver.t
+++ b/t/01-driver.t
@@ -245,7 +245,7 @@ FIND: {
       . " at " . __FILE__ . " line " . (__LINE__+1);
     eval { $driver->find_element("element_that_doesnt_exist","id"); };
     chomp $@;
-    is($@,$expected_err.".","find_element croaks properly");
+    like($@,qr/$expected_err/,"find_element croaks properly");
     my $elems = $driver->find_elements("//input[\@id='checky']");
     is(scalar(@$elems),1, 'Got an arrayref of WebElements');
     my @array_elems = $driver->find_elements("//input[\@id='checky']");


### PR DESCRIPTION
I have folded the 2 lines for 'got/expected' for readability:

```
$ make test
PERL_DL_NONLAZY=1 /usr/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00-load.t ............................. ok   
t/01-driver.t ........................... 1/? 
#   Failed test 'find_element croaks properly'
#   at t/01-driver.t line 259.
#          got: 'An element could not be located on the page using the given search parameters: \
#                element_that_doesnt_exist,id at t/01-driver.t line 257'
#     expected: 'An element could not be located on the page using the given search parameters: \
#                element_that_doesnt_exist,id at t/01-driver.t line 257.'
```

Note the period at the end of the 'expected' line, after the '7'.

I fixed this for my situation using this patch:

```
259c259
<     is($@,$expected_err.".","find_element croaks properly");

---
>     is($@,$expected_err,"find_element croaks properly");
```

But I'm not sure this is a particularly valid fix.  It seems like some sort of regex might be better.

Bob
