### PR TITLE
jQuery-dependent simulated drag workaround

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires "Carp" => "0";
 requires "Cwd" => "0";
 requires "Data::Dumper" => "0";
 requires "Exporter" => "0";
+requires "File::Basename" => "0";
 requires "File::Copy" => "0";
 requires "File::Temp" => "0";
 requires "HTTP::Headers" => "0";
@@ -30,7 +31,6 @@ requires "strict" => "0";
 requires "warnings" => "0";
 
 on 'test' => sub {
-  requires "File::Basename" => "0";
   requires "File::stat" => "0";
   requires "FindBin" => "0";
   requires "IO::Socket::INET" => "0";

--- a/lib/Selenium/Remote/drag.js
+++ b/lib/Selenium/Remote/drag.js
@@ -1,0 +1,53 @@
+(function( $ ) {
+    $.fn.simulateDragDrop = function(options) {
+        return this.each(function() {
+            new $.simulateDragDrop(this, options);
+        });
+    };
+    $.simulateDragDrop = function(elem, options) {
+        this.options = options;
+        this.simulateEvent(elem, options);
+    };
+    $.extend($.simulateDragDrop.prototype, {
+        simulateEvent: function(elem, options) {
+            /*Simulating drag start*/
+            var type = 'dragstart';
+            var event = this.createEvent(type);
+            this.dispatchEvent(elem, type, event);
+
+            /*Simulating drop*/
+            type = 'drop';
+            var dropEvent = this.createEvent(type, {});
+            dropEvent.dataTransfer = event.dataTransfer;
+            this.dispatchEvent($(options.dropTarget)[0], type, dropEvent);
+
+            /*Simulating drag end*/
+            type = 'dragend';
+            var dragEndEvent = this.createEvent(type, {});
+            dragEndEvent.dataTransfer = event.dataTransfer;
+            this.dispatchEvent(elem, type, dragEndEvent);
+        },
+        createEvent: function(type) {
+            var event = document.createEvent("CustomEvent");
+            event.initCustomEvent(type, true, true, null);
+            event.dataTransfer = {
+                data: {
+                },
+                setData: function(type, val){
+                    this.data[type] = val;
+                },
+                getData: function(type){
+                    return this.data[type];
+                }
+            };
+            return event;
+        },
+        dispatchEvent: function(elem, type, event) {
+            if(elem.dispatchEvent) {
+                elem.dispatchEvent(event);
+            }else if( elem.fireEvent ) {
+                elem.fireEvent("on"+type, event);
+            }
+        }
+    });
+})(jQuery);

--- a/t/02-webelement.t
+++ b/t/02-webelement.t
@@ -88,13 +88,20 @@ IMAGES: {
     ok(defined $ret->{'y'}, 'Image - got y coord');
     my $x = $ret->{'x'};
     my $y = $ret->{'y'};
-  TODO: {
-        local $TODO = "drag doesn't appear to be working currently in selenium server";
-        $ret = $elem->drag(200,200);
-        $ret = $elem->get_element_location();
-        is($ret->{'x'}, ($x+200), 'Moved to new x coord');
-        is($ret->{'y'}, ($y+200), 'Moved to new y coord');
-    }
+}
+
+DRAG_HACK: {
+    $driver->get("$website/dragAndDropTest.html");
+
+    my $grab = $driver->find_element('column-a', 'id');
+    my $target = $driver->find_element('column-b', 'id');
+    is($grab->get_text, 'A', 'before drag, column-a has "A"');
+
+    $ret = $grab->drag($target);
+    is($grab->get_text, 'B', 'after drag, column-a has "B"');
+
+    $target->drag($grab);
+    is($grab->get_text, 'A', 'after second drag, column-a has "A"');
 }
 
 VISIBILITY: {

--- a/t/www/dragAndDropTest.html
+++ b/t/www/dragAndDropTest.html
@@ -65,5 +65,98 @@ document.onmouseup=new Function("isdrag=false");
 <img src="icon.gif" class="dragme" id="test3"><br>
 <img src="icon.gif" class="dragme" id="test4"><br>
 </div>
+
+<div class="drag">
+  <h4>Drag and Drop Test Fixture</h4>
+  <div id="columns">
+    <div class="column" id="column-a" draggable="true"><header>A</header></div>
+    <div class="column" id="column-b" draggable="true"><header>B</header></div>
+  </div>
+</div>
+<br>
+
+<style>
+.drag .columns {
+  width: 400px;
+}
+.drag .column {
+  height: 150px;
+  width: 150px;
+  float: left;
+  border: 2px solid #666666;
+  background-color: #ccc;
+  margin-right: 5px;
+  text-align: center;
+  cursor: move;
+}
+.drag .column.over {
+  border: 2px dashed #000;
+}
+
+</style>
+
+<script>
+var dragSrcEl = null;
+
+function handleDragStart(e) {
+  this.style.opacity = '0.4';
+
+  dragSrcEl = this;
+
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.setData('text/html', this.innerHTML);
+}
+
+function handleDragOver(e) {
+  if (e.preventDefault) {
+    e.preventDefault();
+  }
+
+  e.dataTransfer.dropEffect = 'move';
+
+  return false;
+}
+
+function handleDragEnter(e) {
+  this.classList.add('over');
+}
+
+function handleDragLeave(e) {
+  this.classList.remove('over');
+}
+
+function handleDrop(e) {
+  if (e.stopPropagation) {
+    e.stopPropagation();
+  }
+
+  if (dragSrcEl != this) {
+    dragSrcEl.innerHTML = this.innerHTML;
+    this.innerHTML = e.dataTransfer.getData('text/html');
+  }
+
+  return false;
+}
+
+function handleDragEnd(e) {
+  [].forEach.call(cols, function (col) {
+    col.classList.remove('over');
+  });
+  this.style.opacity = '1';
+}
+
+var cols = document.querySelectorAll('#columns .column');
+[].forEach.call(cols, function(col) {
+  col.addEventListener('dragstart', handleDragStart, false);
+  col.addEventListener('dragenter', handleDragEnter, false);
+  col.addEventListener('dragover', handleDragOver, false);
+  col.addEventListener('dragleave', handleDragLeave, false);
+  col.addEventListener('drop', handleDrop, false);
+  col.addEventListener('dragend', handleDragEnd, false);
+});
+</script>
+
+
+<script src="jquery-1.3.2.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Anyone interested in this? Using the method that [Dave Haeffner outlines](http://elementalselenium.com/tips/39-drag-and-drop), we can get drag working again for HTML5 pages. 

downsides:

* hard dependency on jQuery either being on the page or manually loaded in webdriver
* dragging is not actually in the JSONWireProtocol
* We'd have to include a js file in this perl module (where to put it?)
* doesn't seem to always work, may depend on the drag implementation of the actual page under test
* The "preferred" implementation used by other bindings is ActionChains, and when the webdriver bug is fixed, we'll need to deprecate this again
* The previous implementation of drag wanted pixel coordinates, and we're changing that API to want a WebElement (this is ... not really a huge deal, as the previous implementation was completely busted).

upsides:

* we could actually drag something. I tried out a python ActionChains example and it failed as expected due to the [aforementioned webdriver bug](https://code.google.com/p/selenium/issues/detail?id=6315), so even the "preferred" actionchains method doesn't work. 