### PR TITLE
'find_element'-like functions in Test::Selenium::Remote::Driver should support a locator strategy as an argument

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -36,6 +36,7 @@ use constant FINDERS => {
     xpath             => 'xpath',
 };
 
+
 =head1 SYNOPSIS
 
     use Selenium::Remote::Driver;

--- a/lib/Selenium/Remote/Mock/RemoteConnection.pm
+++ b/lib/Selenium/Remote/Mock/RemoteConnection.pm
@@ -147,10 +147,6 @@ sub request {
     my $ret = { cmd_status => 'OK', cmd_return => 1 };
     if ( defined( $spec->{$cmd} ) ) {
         my $return_sub = $spec->{$cmd};
-        if ($no_content_success) {
-            $ret->{cmd_return} = 1;
-        }
-        else {
             my $mock_return = $return_sub->( $url_params, $params );
             if ( ref($mock_return) eq 'HASH' ) {
                 $ret->{cmd_status} = $mock_return->{status};
@@ -160,7 +156,6 @@ sub request {
             else {
                 $ret = $mock_return;
             }
-        }
         $ret->{session_id} = $self->fake_session_id if ( ref($ret) eq 'HASH' );
     }
     else {

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -239,17 +239,8 @@ more documentation, see the related test methods in L<Selenium::Remote::Driver>
 
     click_ok
     double_click_ok
-
-=head2 $twd->type_element_ok($search_target [,$locator], $keys, [, $desc ]);
-
-   $twd->type_element_ok( $search_target [,$locator], $keys [, $desc ] );
-
-Use L<Selenium::Remote::Driver/find_element> to resolve the C<$search_target>
-to a web element and an optional locator, and then type C<$keys> into it, providing an optional test
-label.
-
-
 =cut
+
 
 # function composing a find_element with locator with a webelement test
 
@@ -264,7 +255,7 @@ sub _find_element_with_action {
     else { 
         if ($params) { 
             # means that we called it the 'old way' (no locator strategy)
-            if (!$self->FINDERS->{$locator_strategy}) { 
+            if (!defined($self->FINDERS->{$locator_strategy})) { 
                 $desc = $params; 
                 $params = $locator_strategy; 
                 $locator_strategy = $self->default_finder;
@@ -273,7 +264,7 @@ sub _find_element_with_action {
         else { 
             # means it was called with no locator strategy and no desc 
             if ($locator_strategy) { 
-                if (!$self->FINDERS->{$locator_strategy}) { 
+                if (!defined($self->FINDERS->{$locator_strategy})) { 
                     $params = $locator_strategy; 
                     $locator_strategy = $self->default_finder;
                 }
@@ -290,6 +281,17 @@ sub _find_element_with_action {
     return $self->find_element($locator,$locator_strategy)->$method( $params, $desc );
 }
 
+
+=head2 $twd->type_element_ok($search_target [,$locator], $keys, [, $desc ]);
+
+   $twd->type_element_ok( $search_target [,$locator], $keys [, $desc ] );
+
+Use L<Selenium::Remote::Driver/find_element> to resolve the C<$search_target>
+to a web element and an optional locator, and then type C<$keys> into it, providing an optional test
+label.
+
+
+=cut
 
 sub type_element_ok {
     my $self    = shift;

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -240,24 +240,47 @@ more documentation, see the related test methods in L<Selenium::Remote::Driver>
     click_ok
     double_click_ok
 
-=head2 $twd->type_element_ok($search_target, $keys, [, $desc ]);
+=head2 $twd->type_element_ok($search_target [,$locator], $keys, [, $desc ]);
 
-   $twd->type_element_ok( $search_target, $keys [, $desc ] );
+   $twd->type_element_ok( $search_target [,$locator], $keys [, $desc ] );
 
 Use L<Selenium::Remote::Driver/find_element> to resolve the C<$search_target>
-to a web element, and then type C<$keys> into it, providing an optional test
+to a web element and an optional locator, and then type C<$keys> into it, providing an optional test
 label.
 
-Currently, other finders besides the default are not supported for C<type_ok()>.
 
 =cut
 
 sub type_element_ok {
     my $self    = shift;
-    my $locator = shift;
-    my $keys    = shift;
-    my $desc    = shift;
-    return $self->find_element($locator)->send_keys_ok( $keys, $desc );
+    my ($locator,$locator_strategy,$keys,$desc) = @_;
+    # case 4 args 
+    if ($desc) { 
+        $self->croak('Invalid locator strategy') unless ($self->FINDERS->{$locator_strategy});
+    }
+    else { 
+        if ($keys) { 
+            # means that we called it the 'old way' (no locator strategy)
+            if (!$self->FINDERS->{$locator_strategy}) { 
+                $desc = $keys; 
+                $keys = $locator_strategy; 
+                $locator_strategy = $self->default_finder;
+            }
+        }
+        else { 
+            # means it was called with no locator strategy and no desc 
+            if ($locator_strategy) { 
+                if (!$self->FINDERS->{$locator_strategy}) { 
+                    $keys = $locator_strategy; 
+                    $locator_strategy = $self->default_finder;
+                }
+            }
+            else { 
+                $self->croak('Not enough arguments');
+            }
+        }
+    }
+    return $self->find_element($locator,$locator_strategy)->send_keys_ok( $keys, $desc );
 }
 
 

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -33,7 +33,7 @@ has func_list => (
             'send_modifier_ok', 'accept_alert_ok', 'dismiss_alert_ok',
             'get_ok', 'go_back_ok', 'go_forward_ok', 'add_cookie_ok',
             'get_page_source_ok', 'find_element_ok', 'find_elements_ok',
-            'find_child_element_ok', 'find_child_elements_ok',
+            'find_child_element_ok', 'find_child_elements_ok', 'find_no_element_ok',
             'compare_elements_ok', 'click_ok', 'double_click_ok',
             'body_like',
         ];
@@ -45,7 +45,7 @@ sub has_args {
     my $fun_name      = shift;
     my $hash_fun_args = {
         'find_element'     => 2,
-        'find_no_element_ok' => 2,
+        'find_no_element' => 2,
         'find_child_element'     => 3,
         'find_child_elements'     => 3,
         'find_element'     => 2,
@@ -286,10 +286,6 @@ for C<find_no_element_ok()>.
 
 =cut
 
-sub find_no_element_ok {
-    my $self = shift;
-    $self->_check_ok('find_no_element_ok',@_);
-}
 
 =head2 $twd->content_like( $regex [, $desc ] )
 

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -503,12 +503,12 @@ sub body_text_like {
     my $text = $self->get_body();
 
     if ( not ref $regex eq 'ARRAY' ) {
-        my $desc = qq{Text is like "$regex"} if ( not defined $desc );
+        $desc = qq{Text is like "$regex"} if ( not defined $desc );
         return like_string( $text, $regex, $desc );
     }
     elsif ( ref $regex eq 'ARRAY' ) {
         for my $re (@$regex) {
-            my $desc = qq{Text is like "$re"} if ( not defined $desc );
+            $desc = qq{Text is like "$re"} if ( not defined $desc );
             like_string( $text, $re, $desc );
         }
     }
@@ -541,12 +541,12 @@ sub body_text_unlike {
     my $text = $self->get_body();
 
     if ( not ref $regex eq 'ARRAY' ) {
-        my $desc = qq{Text is unlike "$regex"} if ( not defined $desc );
+        $desc = qq{Text is unlike "$regex"} if ( not defined $desc );
         return unlike_string( $text, $regex, $desc );
     }
     elsif ( ref $regex eq 'ARRAY' ) {
         for my $re (@$regex) {
-            my $desc = qq{Text is unlike "$re"} if ( not defined $desc );
+            $desc = qq{Text is unlike "$re"} if ( not defined $desc );
             unlike_string( $text, $re, $desc );
         }
     }
@@ -578,12 +578,12 @@ sub content_contains {
     my $content = $self->get_page_source();
 
     if ( not ref $str eq 'ARRAY' ) {
-        my $desc = qq{Content contains "$str"} if ( not defined $desc );
+        $desc = qq{Content contains "$str"} if ( not defined $desc );
         return contains_string( $content, $str, $desc );
     }
     elsif ( ref $str eq 'ARRAY' ) {
         for my $s (@$str) {
-            my $desc = qq{Content contains "$s"} if ( not defined $desc );
+            $desc = qq{Content contains "$s"} if ( not defined $desc );
             contains_string( $content, $s, $desc );
         }
     }
@@ -613,12 +613,12 @@ sub content_lacks {
     my $content = $self->get_page_source();
 
     if ( not ref $str eq 'ARRAY' ) {
-        my $desc = qq{Content lacks "$str"} if ( not defined $desc );
+        $desc = qq{Content lacks "$str"} if ( not defined $desc );
         return lacks_string( $content, $str, $desc );
     }
     elsif ( ref $str eq 'ARRAY' ) {
         for my $s (@$str) {
-            my $desc = qq{Content lacks "$s"} if ( not defined $desc );
+            $desc = qq{Content lacks "$s"} if ( not defined $desc );
             lacks_string( $content, $s, $desc );
         }
     }
@@ -651,12 +651,12 @@ sub body_text_contains {
     my $text = $self->get_body();
 
     if ( not ref $str eq 'ARRAY' ) {
-        my $desc = qq{Text contains "$str"} if ( not defined $desc );
+        $desc = qq{Text contains "$str"} if ( not defined $desc );
         return contains_string( $text, $str, $desc );
     }
     elsif ( ref $str eq 'ARRAY' ) {
         for my $s (@$str) {
-            my $desc = qq{Text contains "$s"} if ( not defined $desc );
+            $desc = qq{Text contains "$s"} if ( not defined $desc );
             contains_string( $text, $s, $desc );
         }
     }
@@ -689,12 +689,12 @@ sub body_text_lacks {
     my $text = $self->get_body();
 
     if ( not ref $str eq 'ARRAY' ) {
-        my $desc = qq{Text is lacks "$str"} if ( not defined $desc );
+        $desc = qq{Text is lacks "$str"} if ( not defined $desc );
         return lacks_string( $text, $str, $desc );
     }
     elsif ( ref $str eq 'ARRAY' ) {
         for my $s (@$str) {
-            my $desc = qq{Text is lacks "$s"} if ( not defined $desc );
+            $desc = qq{Text is lacks "$s"} if ( not defined $desc );
             lacks_string( $text, $s, $desc );
         }
     }

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -45,6 +45,7 @@ sub has_args {
     my $fun_name      = shift;
     my $hash_fun_args = {
         'find_element'     => 2,
+        'find_no_element_ok' => 2,
         'find_child_element'     => 3,
         'find_child_elements'     => 3,
         'find_element'     => 2,
@@ -286,17 +287,8 @@ for C<find_no_element_ok()>.
 =cut
 
 sub find_no_element_ok {
-    my $self          = shift;
-    my $search_target = shift;
-    my $desc          = shift;
-    my $rv = 0 ;
-    local $Test::Builder::Level = $Test::Builder::Level + 1;
-    try {
-        $self->find_element($search_target)
-    } catch {
-        $rv = 1 if ($_);
-    };
-    return $self->ok($rv == 1,$desc);
+    my $self = shift;
+    $self->_check_ok('find_no_element_ok',@_);
 }
 
 =head2 $twd->content_like( $regex [, $desc ] )

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -261,27 +261,27 @@ sub type_element_ok {
 }
 
 
-=head2 $twd->find_element_ok($search_target [, $desc ]);
+=head2 $twd->find_element_ok($search_target [,$finder, $desc ]);
 
-   $twd->find_element_ok( $search_target [, $desc ] );
+   $twd->find_element_ok( $search_target [,$finder, $desc ] );
 
 Returns true if C<$search_target> is successfully found on the page. L<$search_target>
-is passed to L<Selenium::Remote::Driver/find_element> using the C<default_finder>. See
-there for more details on the format. Currently, other finders besides the default are not supported
-for C<find_element_ok()>.
+is passed to L<Selenium::Remote::Driver/find_element> using a finder or the C<default_finder>
+if none passed.
+See there for more details on the format for C<find_element_ok()>.
 
 =cut
 
 # Eventually, it would be nice to support other finds like Test::WWW::Selenium does, like this:
 # 'xpath=//foo', or 'css=.foo', etc.
 
-=head2 $twd->find_no_element_ok($search_target [, $desc ]);
+=head2 $twd->find_no_element_ok($search_target [,$finder, $desc ]);
 
-   $twd->find_no_element_ok( $search_target [, $desc ] );
+   $twd->find_no_element_ok( $search_target [,$finder, $desc ] );
 
 Returns true if C<$search_target> is I<not> found on the page. L<$search_target>
-is passed to L<Selenium::Remote::Driver/find_element> using the C<default_finder>. See
-there for more details on the format. Currently, other finders besides the default are not supported
+is passed to L<Selenium::Remote::Driver/find_element> using a finder or the
+C<default_finder> if none passed.See there for more details on the format. 
 for C<find_no_element_ok()>.
 
 =cut

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -344,18 +344,17 @@ sub content_unlike {
     my $self  = shift;
     my $regex = shift;
     my $desc  = shift;
-
     local $Test::Builder::Level = $Test::Builder::Level + 1;
 
     my $content = $self->get_page_source();
 
     if ( not ref $regex eq 'ARRAY' ) {
-        my $desc = qq{Content is unlike "$regex"} if ( not defined $desc );
+        $desc = qq{Content is unlike "$regex"} if ( not defined $desc );
         return unlike_string( $content, $regex, $desc );
     }
     elsif ( ref $regex eq 'ARRAY' ) {
         for my $re (@$regex) {
-            my $desc = qq{Content is unlike "$re"} if ( not defined $desc );
+            $desc = qq{Content is unlike "$re"} if ( not defined $desc );
             unlike_string( $content, $re, $desc );
         }
     }

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -45,6 +45,9 @@ sub has_args {
     my $fun_name      = shift;
     my $hash_fun_args = {
         'find_element'     => 2,
+        'find_child_element'     => 3,
+        'find_child_elements'     => 3,
+        'find_element'     => 2,
         'find_elements'     => 2,
         'compare_elements' => 2,
         'get' => 1,

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -44,8 +44,8 @@ sub has_args {
     my $self          = shift;
     my $fun_name      = shift;
     my $hash_fun_args = {
-        'find_element'     => 1,
-        'find_elements'     => 1,
+        'find_element'     => 2,
+        'find_elements'     => 2,
         'compare_elements' => 2,
         'get' => 1,
     };

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -51,37 +51,19 @@ sub _check_ok {
     try {
         $num_of_args = $self->has_args($method);
         @r_args = splice( @args, 0, $num_of_args );
-        if ($method =~ m/^find(_no)?_element/) { 
+        if ($method =~ m/^find(_no|_child)?_element/) { 
             # case find_element_ok was called with no arguments    
-            if (scalar(@r_args) == 1) { 
+            if (scalar(@r_args) - $num_of_args == 1) { 
                 push @r_args, $self->default_finder; 
             }
             else { 
-                if (scalar(@r_args) == 2) { 
+                if (scalar(@r_args) == $num_of_args) {
                     # case find_element was called with no finder but
                     # a test description
-                    my $finder = $r_args[1]; 
+                    my $finder = $r_args[$num_of_args - 1]; 
                     my @FINDERS = keys (%{$self->FINDERS});
                     unless ( any { $finder eq $_ } @FINDERS) { 
-                        $r_args[1] = $self->default_finder; 
-                        push @args, $finder; 
-                    }
-                }
-            }
-        }
-        if ($method =~ m/^find_child_element/) { 
-            # case find_element_ok was called with no arguments    
-            if (scalar(@r_args) == 2) { 
-                push @r_args, $self->default_finder; 
-            }
-            else { 
-                if (scalar(@r_args) == 3) { 
-                    # case find_element was called with no finder but
-                    # a test description
-                    my $finder = $r_args[2]; 
-                    my @FINDERS = keys (%{$self->FINDERS});
-                    unless ( any { $finder eq $_ } @FINDERS) { 
-                        $r_args[2] = $self->default_finder; 
+                        $r_args[$num_of_args - 1] = $self->default_finder; 
                         push @args, $finder; 
                     }
                 }

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -39,16 +39,19 @@ sub _check_method {
 }
 
 # main method for _ok tests
+# a bit hacked so that find_no_element_ok can also be processed
+# TODO: maybe simplify a bit the logic 
 
 sub _check_ok {
     my $self   = shift;
     my $method = shift;
+    my $real_method = '';
     my @args   = @_;
     my ($rv, $num_of_args, @r_args);
     try {
         $num_of_args = $self->has_args($method);
         @r_args = splice( @args, 0, $num_of_args );
-        if ($method =~ m/^find_element/) { 
+        if ($method =~ m/^find(_no)?_element/) { 
             # case find_element_ok was called with no arguments    
             if (scalar(@r_args) == 1) { 
                 push @r_args, $self->default_finder; 
@@ -84,10 +87,20 @@ sub _check_ok {
                 }
             }
         }
+        if ($method eq 'find_no_element_ok') { 
+            $real_method = $method;
+            $method = 'find_element'; 
+        }
         $rv = $self->$method(@r_args);
     }
     catch {
-        $self->croak($_);
+        if ($real_method) {
+            $method = $real_method;
+            $rv     = 1;
+        }
+        else {
+            $self->croak($_);
+        }
     };
 
     my $default_test_name = $method;

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -40,7 +40,6 @@ sub _check_method {
 
 # main method for _ok tests
 # a bit hacked so that find_no_element_ok can also be processed
-# TODO: maybe simplify a bit the logic 
 
 sub _check_ok {
     my $self   = shift;
@@ -69,6 +68,7 @@ sub _check_ok {
                 }
             }
         }
+        # quick hack to fit 'find_no_element' into check_ok logic
         if ($method eq 'find_no_element') { 
             $real_method = $method;
             $method = 'find_element'; 

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -27,7 +27,6 @@ sub _check_method {
     my @args = @_;
     my $rv;
     try {
-        $DB::single = 1;
         my $num_of_args = $self->has_args($method);
         my @r_args = splice( @args, 0, $num_of_args );
         $rv = $self->$method(@r_args);

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -69,7 +69,7 @@ sub _check_ok {
                 }
             }
         }
-        if ($method eq 'find_no_element_ok') { 
+        if ($method eq 'find_no_element') { 
             $real_method = $method;
             $method = 'find_element'; 
         }

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -49,7 +49,7 @@ sub _check_ok {
         $num_of_args = $self->has_args($method);
         @r_args = splice( @args, 0, $num_of_args );
         if ($method =~ m/^find_element/) { 
-            # case find_element*_ok was called with no arguments    
+            # case find_element_ok was called with no arguments    
             if (scalar(@r_args) == 1) { 
                 push @r_args, $self->default_finder; 
             }
@@ -61,6 +61,24 @@ sub _check_ok {
                     my @FINDERS = keys (%{$self->FINDERS});
                     unless ( any { $finder eq $_ } @FINDERS) { 
                         $r_args[1] = $self->default_finder; 
+                        push @args, $finder; 
+                    }
+                }
+            }
+        }
+        if ($method =~ m/^find_child_element/) { 
+            # case find_element_ok was called with no arguments    
+            if (scalar(@r_args) == 2) { 
+                push @r_args, $self->default_finder; 
+            }
+            else { 
+                if (scalar(@r_args) == 3) { 
+                    # case find_element was called with no finder but
+                    # a test description
+                    my $finder = $r_args[2]; 
+                    my @FINDERS = keys (%{$self->FINDERS});
+                    unless ( any { $finder eq $_ } @FINDERS) { 
+                        $r_args[2] = $self->default_finder; 
                         push @args, $finder; 
                     }
                 }

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -27,6 +27,7 @@ sub _check_method {
     my @args = @_;
     my $rv;
     try {
+        $DB::single = 1;
         my $num_of_args = $self->has_args($method);
         my @r_args = splice( @args, 0, $num_of_args );
         $rv = $self->$method(@r_args);

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -16,6 +16,9 @@ my $find_element = sub {
     {
         return { status => 'OK', return => { ELEMENT => '123457' } };
     }
+    if ( $searched_item->{value} eq '//body' && $searched_item->{using} eq 'xpath') { 
+        return { status => 'OK', return => { ELEMENT => '123458' } };
+    }
     return { status => 'NOK', return => 0, error => 'element not found' };
 };
 my $find_child_element = sub {
@@ -59,6 +62,7 @@ my $get_text = sub {
     my ($session_object) =@_; 
     return 'abc' if ($session_object->{id} eq '123456');
     return 'def' if ($session_object->{id} eq '123457');
+    return 'this output matches' if ($session_object->{id} eq '123458');
     return;
 };
 
@@ -105,9 +109,15 @@ dies_ok{ $successful_driver->find_child_element_ok({id => 1200}) } 'find_child_e
 
 $successful_driver->find_no_element_ok('notq','xpath','find_no_element_ok works');
 
-
+# body and content function family 
 $successful_driver->content_like( qr/matches/, 'content_like works');
 $successful_driver->content_unlike( qr/nomatch/, 'content_unlike works');
+$successful_driver->content_contains( 'matches', 'content_contains works');
+$successful_driver->content_lacks( 'nomatch', 'content_lacks works');
+$successful_driver->body_text_contains( ['match','output'], 'body_text_contains works');
+$successful_driver->body_text_lacks( 'nomatch', 'body_text_lacks works');
+$successful_driver->body_text_like( qr/this/, 'body_text_like works');
+$successful_driver->body_text_unlike( qr/notthis/, 'body_text_unlike works');
 
 $successful_driver->type_element_ok('q','abc');
 $successful_driver->type_element_ok('p','class','def','type_element_ok works with a locator');

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -5,6 +5,8 @@ use Test::Selenium::Remote::Driver;
 use Selenium::Remote::WebElement;
 use Selenium::Remote::Mock::Commands;
 use Selenium::Remote::Mock::RemoteConnection;
+use DDP; 
+
 my $find_element = sub {
     my ( undef, $searched_item ) = @_;
     if ( $searched_item->{value} eq 'q' ) {
@@ -47,12 +49,20 @@ my $find_elements = sub {
     }
 };
 
+my $send_keys = sub {
+        my ( $session_object, $val ) = @_;
+        my $keys = shift @{ $val->{value} };
+        return { status => 'OK', return => 1 } if ( $keys =~ /abc|def/ );
+        return { status => 'NOK', return => 0, error => 'cannot send keys' };
+      };
+
 my $spec = {
     findElement => $find_element,
     findChildElement => $find_child_element,
     getPageSource => sub { return 'this output matches regex'},
     findElements => $find_elements,
     findChildElements => $find_child_element,
+    sendKeysToElement => $send_keys,
 };
 
 my $mock_commands = Selenium::Remote::Mock::Commands->new;
@@ -72,5 +82,7 @@ $successful_driver->content_like( qr/matches/, 'content_like works');
 $successful_driver->content_unlike( qr/nomatch/, 'content_unlike works');
 $successful_driver->find_elements_ok('abc','find_elements_ok works');
 $successful_driver->find_child_elements_ok({id => 1},'p','find_child_elements_ok works');
+$successful_driver->type_element_ok('q','abc');
+$successful_driver->type_element_ok('p','class','def','type_element_ok works with a locator');
 
 done_testing();

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -8,15 +8,21 @@ use Selenium::Remote::Mock::RemoteConnection;
 
 my $spec = {
     findElement => sub {
-        my (undef,$searched_item) = @_;
-        return { status => 'OK', return => { ELEMENT => '123456' } }
-          if ( $searched_item->{value} eq 'q' );
+        my ( undef, $searched_item ) = @_;
+        if ( $searched_item->{value} eq 'q' ) {
+            return { status => 'OK', return => { ELEMENT => '123456' } };
+        }
+        if (   $searched_item->{value} eq 'p'
+            && $searched_item->{using} eq 'class name' )
+        {
+            return { status => 'OK', return => { ELEMENT => '123456' } };
+        }
         return { status => 'NOK', return => 0, error => 'element not found' };
-    },
+      },
     getPageSource => sub { return 'this output matches regex'},
     findElements => sub { 
         my (undef,$searched_expr) = @_;
-        if ($searched_expr) { 
+        if ($searched_expr->{value} eq 'abc' && $searched_expr->{using} eq 'xpath') { 
             return { status => 'OK', return => [ { ELEMENT => '123456' }, { ELEMENT => '12341234' } ] }
         }
     },
@@ -29,6 +35,7 @@ my $successful_driver =
     commands => $mock_commands,
 );
 $successful_driver->find_element_ok('q','find_element_ok works');
+$successful_driver->find_element_ok('p','class','find_element_ok with a locator works');
 dies_ok { $successful_driver->find_element_ok('notq') } 'find_element_ok dies if element not found';
 $successful_driver->find_no_element_ok('notq','find_no_element_ok works');
 $successful_driver->content_like( qr/matches/, 'content_like works');

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -67,7 +67,7 @@ $successful_driver->find_element_ok('p','class','find_element_ok with a locator 
 $successful_driver->find_child_element_ok({id => 1},'p','class','find_child_element_ok with a locator works');
 dies_ok{ $successful_driver->find_child_element_ok({id => 1200}) } 'find_child_element_ok dies if the element is not found';
 dies_ok { $successful_driver->find_element_ok('notq') } 'find_element_ok dies if element not found';
-$successful_driver->find_no_element_ok('notq','find_no_element_ok works');
+$successful_driver->find_no_element_ok('notq','xpath','find_no_element_ok works');
 $successful_driver->content_like( qr/matches/, 'content_like works');
 $successful_driver->content_unlike( qr/nomatch/, 'content_unlike works');
 $successful_driver->find_elements_ok('abc','find_elements_ok works');

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -5,28 +5,56 @@ use Test::Selenium::Remote::Driver;
 use Selenium::Remote::WebElement;
 use Selenium::Remote::Mock::Commands;
 use Selenium::Remote::Mock::RemoteConnection;
+my $find_element = sub {
+    my ( undef, $searched_item ) = @_;
+    if ( $searched_item->{value} eq 'q' ) {
+        return { status => 'OK', return => { ELEMENT => '123456' } };
+    }
+    if (   $searched_item->{value} eq 'p'
+        && $searched_item->{using} eq 'class name' )
+    {
+        return { status => 'OK', return => { ELEMENT => '123456' } };
+    }
+    return { status => 'NOK', return => 0, error => 'element not found' };
+};
+my $find_child_element = sub {
+    my ( $session_object, $searched_item ) = @_;
+    my $elem_id = $session_object->{id};
+    if ( $elem_id == 1 && $searched_item->{value} eq 'p' ) {
+        if ( $searched_item->{using} eq 'class name' ) {
+            return { status => 'OK', return => { ELEMENT => '11223344' } };
+        }
+
+        if ( $searched_item->{using} eq 'xpath' ) {
+            return { status => 'OK',
+                return => [ { ELEMENT => '112' }, { ELEMENT => '113' } ] };
+        }
+    }
+
+    return {
+        status => 'NOK', return => 0,
+        error  => 'child element not found'
+    };
+};
+
+my $find_elements = sub {
+    my ( undef, $searched_expr ) = @_;
+    if (   $searched_expr->{value} eq 'abc'
+        && $searched_expr->{using} eq 'xpath' )
+    {
+        return { status => 'OK',
+            return => [ { ELEMENT => '123456' }, { ELEMENT => '12341234' } ] };
+    }
+};
 
 my $spec = {
-    findElement => sub {
-        my ( undef, $searched_item ) = @_;
-        if ( $searched_item->{value} eq 'q' ) {
-            return { status => 'OK', return => { ELEMENT => '123456' } };
-        }
-        if (   $searched_item->{value} eq 'p'
-            && $searched_item->{using} eq 'class name' )
-        {
-            return { status => 'OK', return => { ELEMENT => '123456' } };
-        }
-        return { status => 'NOK', return => 0, error => 'element not found' };
-      },
+    findElement => $find_element,
+    findChildElement => $find_child_element,
     getPageSource => sub { return 'this output matches regex'},
-    findElements => sub { 
-        my (undef,$searched_expr) = @_;
-        if ($searched_expr->{value} eq 'abc' && $searched_expr->{using} eq 'xpath') { 
-            return { status => 'OK', return => [ { ELEMENT => '123456' }, { ELEMENT => '12341234' } ] }
-        }
-    },
+    findElements => $find_elements,
+    findChildElements => $find_child_element,
 };
+
 my $mock_commands = Selenium::Remote::Mock::Commands->new;
 
 my $successful_driver =
@@ -36,10 +64,13 @@ my $successful_driver =
 );
 $successful_driver->find_element_ok('q','find_element_ok works');
 $successful_driver->find_element_ok('p','class','find_element_ok with a locator works');
+$successful_driver->find_child_element_ok({id => 1},'p','class','find_child_element_ok with a locator works');
+dies_ok{ $successful_driver->find_child_element_ok({id => 1200}) } 'find_child_element_ok dies if the element is not found';
 dies_ok { $successful_driver->find_element_ok('notq') } 'find_element_ok dies if element not found';
 $successful_driver->find_no_element_ok('notq','find_no_element_ok works');
 $successful_driver->content_like( qr/matches/, 'content_like works');
 $successful_driver->content_unlike( qr/nomatch/, 'content_unlike works');
 $successful_driver->find_elements_ok('abc','find_elements_ok works');
+$successful_driver->find_child_elements_ok({id => 1},'p','find_child_elements_ok works');
 
 done_testing();

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -15,7 +15,7 @@ my $find_element = sub {
     if (   $searched_item->{value} eq 'p'
         && $searched_item->{using} eq 'class name' )
     {
-        return { status => 'OK', return => { ELEMENT => '123456' } };
+        return { status => 'OK', return => { ELEMENT => '123457' } };
     }
     return { status => 'NOK', return => 0, error => 'element not found' };
 };
@@ -50,11 +50,23 @@ my $find_elements = sub {
 };
 
 my $send_keys = sub {
-        my ( $session_object, $val ) = @_;
-        my $keys = shift @{ $val->{value} };
-        return { status => 'OK', return => 1 } if ( $keys =~ /abc|def/ );
-        return { status => 'NOK', return => 0, error => 'cannot send keys' };
-      };
+    my ( $session_object, $val ) = @_;
+    my $keys = shift @{ $val->{value} };
+    return { status => 'OK', return => 1 } if ( $keys =~ /abc|def/ );
+    return { status => 'NOK', return => 0, error => 'cannot send keys' };
+};
+
+my $get_text = sub { 
+    my ($session_object) =@_; 
+    return 'abc' if ($session_object->{id} eq '123456');
+    return 'def' if ($session_object->{id} eq '123457');
+    return;
+};
+
+my $get_attr = sub { 
+    my ($session_object) = @_;
+    return 'foo';
+};
 
 my $spec = {
     findElement => $find_element,
@@ -62,7 +74,13 @@ my $spec = {
     getPageSource => sub { return 'this output matches regex'},
     findElements => $find_elements,
     findChildElements => $find_child_element,
+    getElementText => $get_text,
     sendKeysToElement => $send_keys,
+    getElementAttribute => $get_attr, 
+    clickElement => sub { return { status => 'OK', return => 1 }; }, 
+    clearElement =>  sub { return { status => 'OK', return => 1 }; }, 
+    isElementDisplayed =>  sub { return { status => 'OK', return => 1 }; }, 
+    isElementEnabled =>  sub { return { status => 'OK', return => 1 }; }, 
 };
 
 my $mock_commands = Selenium::Remote::Mock::Commands->new;
@@ -72,17 +90,37 @@ my $successful_driver =
     remote_conn => Selenium::Remote::Mock::RemoteConnection->new( spec => $spec, mock_cmds => $mock_commands ),
     commands => $mock_commands,
 );
+
+# find element ok tests 
 $successful_driver->find_element_ok('q','find_element_ok works');
 $successful_driver->find_element_ok('p','class','find_element_ok with a locator works');
+dies_ok { $successful_driver->find_element_ok('notq') } 'find_element_ok dies if element not found';
+$successful_driver->find_elements_ok('abc','find_elements_ok works');
+
+# find child element ok tests 
+$successful_driver->find_child_elements_ok({id => 1},'p','find_child_elements_ok works');
 $successful_driver->find_child_element_ok({id => 1},'p','class','find_child_element_ok with a locator works');
 dies_ok{ $successful_driver->find_child_element_ok({id => 1200}) } 'find_child_element_ok dies if the element is not found';
-dies_ok { $successful_driver->find_element_ok('notq') } 'find_element_ok dies if element not found';
+
+# find no element ok test
+
 $successful_driver->find_no_element_ok('notq','xpath','find_no_element_ok works');
+
+
 $successful_driver->content_like( qr/matches/, 'content_like works');
 $successful_driver->content_unlike( qr/nomatch/, 'content_unlike works');
-$successful_driver->find_elements_ok('abc','find_elements_ok works');
-$successful_driver->find_child_elements_ok({id => 1},'p','find_child_elements_ok works');
+
 $successful_driver->type_element_ok('q','abc');
 $successful_driver->type_element_ok('p','class','def','type_element_ok works with a locator');
+
+$successful_driver->element_text_is('q','abc','element has a correct text');
+$successful_driver->element_text_is('p','class','def');
+
+$successful_driver->element_value_is('p','class','foo');
+$successful_driver->click_element_ok('p','class','click_element_ok works');
+$successful_driver->clear_element_ok('q','element is cleared ok');
+$successful_driver->is_element_enabled_ok('p','class','element is enabled');
+$successful_driver->is_element_displayed_ok('q','element is displayed');
+
 
 done_testing();

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -5,7 +5,6 @@ use Test::Selenium::Remote::Driver;
 use Selenium::Remote::WebElement;
 use Selenium::Remote::Mock::Commands;
 use Selenium::Remote::Mock::RemoteConnection;
-use DDP; 
 
 my $find_element = sub {
     my ( undef, $searched_item ) = @_;


### PR DESCRIPTION
I raise this issue mainly because I found myself writing a lot lately : 
```perl 
$driver->default_finder('id');
$driver->find_element_ok('some_id', 'my element was found'); 
$driver->default_finder('xpath'); 
$driver->find_element_ok('//some_xpath', 'my other element was found');
```
If we could pass the locator strategy as an argument, it would allow one to write  : 
```perl 
$driver->find_element_ok('some_id','id','my element was found'); 
$driver->find_element_ok('//some_xpath','xpath', 'my other element was found'); 
```
There might be some issues doing this, but overall it would improve the readability of code written with T::S::R::D.