### PR TITLE
Passing finders to some T::S::R::D functions won't work if the default finder has been changed beforehand

### DIFF
--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -258,7 +258,7 @@ sub _find_element_with_action {
             if (!defined($self->FINDERS->{$locator_strategy})) { 
                 $desc = $params; 
                 $params = $locator_strategy; 
-                $locator_strategy = $self->default_finder;
+                $locator_strategy = $self->_get_finder_key($self->default_finder);
             }
         }
         else { 
@@ -266,7 +266,7 @@ sub _find_element_with_action {
             if ($locator_strategy) { 
                 if (!defined($self->FINDERS->{$locator_strategy})) { 
                     $params = $locator_strategy; 
-                    $locator_strategy = $self->default_finder;
+                    $locator_strategy = $self->_get_finder_key($self->default_finder);
                 }
             }
             else { 

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -17,6 +17,17 @@ has _builder => (
 );
 
 
+# get back the key value from an already coerced finder (default finder)
+
+sub _get_finder_key { 
+    my $self = shift; 
+    my $finder_value = shift; 
+    foreach my $k (keys %{$self->FINDERS}) { 
+        return $k if ($self->FINDERS->{$k} eq $finder_value);
+    }
+    return; 
+}
+
 # main method for non ok tests
 
 sub _check_method {
@@ -53,7 +64,7 @@ sub _check_ok {
         if ($method =~ m/^find(_no|_child)?_element/) { 
             # case find_element_ok was called with no arguments    
             if (scalar(@r_args) - $num_of_args == 1) { 
-                push @r_args, $self->default_finder; 
+                push @r_args, $self->_get_finder_key($self->default_finder);
             }
             else { 
                 if (scalar(@r_args) == $num_of_args) {
@@ -62,7 +73,7 @@ sub _check_ok {
                     my $finder = $r_args[$num_of_args - 1]; 
                     my @FINDERS = keys (%{$self->FINDERS});
                     unless ( any { $finder eq $_ } @FINDERS) { 
-                        $r_args[$num_of_args - 1] = $self->default_finder; 
+                        $r_args[$num_of_args - 1] = $self->_get_finder_key($self->default_finder);
                         push @args, $finder; 
                     }
                 }

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -96,7 +96,9 @@ my $successful_driver =
 
 # find element ok tests 
 $successful_driver->find_element_ok('q','find_element_ok works');
-$successful_driver->find_element_ok('p','class','find_element_ok with a locator works');
+$successful_driver->default_finder('class');
+$successful_driver->find_element_ok('p','find_element_ok with a locator works');
+$successful_driver->default_finder('xpath');
 dies_ok { $successful_driver->find_element_ok('notq') } 'find_element_ok dies if element not found';
 $successful_driver->find_elements_ok('abc','find_elements_ok works');
 
@@ -120,7 +122,8 @@ $successful_driver->body_text_like( qr/this/, 'body_text_like works');
 $successful_driver->body_text_unlike( qr/notthis/, 'body_text_unlike works');
 
 $successful_driver->type_element_ok('q','abc');
-$successful_driver->type_element_ok('p','class','def','type_element_ok works with a locator');
+$successful_driver->default_finder('class');
+$successful_driver->type_element_ok('p','def','type_element_ok works with a locator');
 
 $successful_driver->element_text_is('q','abc','element has a correct text');
 $successful_driver->element_text_is('p','class','def');


### PR DESCRIPTION
Basically because there is a coercion on the `default_finder` attribute, which makes the attribute already translated when the default finder was changed. 
The problem is not apparent when your default finder is xpath, but gets visible for something else. 
A solution could be to translate back the finder in T::S::R::D when we use the default finder, so that find_element gets the correct parameter. 