### PR TITLE
WIP: Add attribute option to prevent Driver commands from dying

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -421,6 +421,23 @@ has 'inner_window_size' => (
 
 );
 
+has 'warnings' => (
+    is => 'ro',
+    lazy => 1,
+    default => sub { 0 },
+    trigger => sub {
+        my ($self) = @_;
+
+        if ($self->warnings) {
+            Sub::Install::reinstall_sub({
+                code => \&Carp::carp,
+                into => __PACKAGE__,
+                as   => 'croak',
+            });
+        }
+    }
+);
+
 with 'Selenium::Remote::Finders';
 
 sub BUILD {


### PR DESCRIPTION
Um, this is maybe not the best idea...but, we wouldn't croak all the time. usage:

```perl
my $d = Selenium::Remote::Driver->new(warnings => 1);
$d->get('http://www.google.com');
# These used to croak, now it just carps
$d->find_element('this is sparta', 'css');
# so we actually make it here
say "Still alive, see? Title: " . $d->get_title;
```

```
Error while executing command: An element could not be located on the page using the given search parameters.: Unable to locate element: {"method":"css selector","selector":"this is sparta"}
For documentation on this error, please visit: http://seleniumhq.org/exceptions/no_such_element.html
Build info: version: '2.44.0', revision: '76d78cf', time: '2014-10-23 20:02:37'
System info: host: 'SC1201.local', ip: '192.168.1.108', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.10.2', java.version: '1.7.0_67'
Driver info: driver.version: unknown at /Users/dgempesaw/webdriver.pl line 13.
Still alive, see? Title: Google
```

lol :-1: 