### PR TITLE
Command info when element is stale

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -497,6 +497,8 @@ sub _execute_command {
                 }
                 elsif ( $resp->{cmd_return} ) {
                     if ( ref( $resp->{cmd_return} ) eq 'HASH' ) {
+                        $msg .= ": $res->{command}"
+                          if $res->{command};
                         $msg .= ": $resp->{cmd_return}->{error}->{msg}"
                           if $resp->{cmd_return}->{error}->{msg};
                         $msg .= ": $resp->{cmd_return}->{message}"


### PR DESCRIPTION
Hi folks,

Executing a command on a stale element gives an error but does not show which command failed (see the error below). These type of warnings also do not show a stack trace and it is also not clear which command caused the error.

It would be helpful if the attempted command could be shown in the error as well, to help find which line caused the issue.

To duplicate the below error:
1. Open a page
2. Find an element on the page and store in a variable
3. Refresh the page
4. Attempt to click on the found element

**Patch**
I have created the following patch with this improvement:

```
diff --git a/lib/Selenium/Remote/Driver.pm b/lib/Selenium/Remote/Driver.pm
index e339ad6..69bbe51 100644
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -497,6 +497,8 @@ sub _execute_command {
                 }
                 elsif ( $resp->{cmd_return} ) {
                     if ( ref( $resp->{cmd_return} ) eq 'HASH' ) {
+                       $msg .= ": $res->{command}"
+                         if $res->{command};
                         $msg .= ": $resp->{cmd_return}->{error}->{msg}"
                           if $resp->{cmd_return}->{error}->{msg};
                         $msg .= ": $resp->{cmd_return}->{message}"
```

This would modify the first line of the below error to something like the following:
``` Error while executing command: getElementText: An element command failed because the referenced element is no longer attached to the DOM.: stale element reference: element is not attached to the page document ```

**Current Error**
```
Error while executing command: An element command failed because the referenced element is no longer attached to the DOM.: stale element reference: element is not attached to the page document
 (Session info: chrome=38.0.2125.122)
 (Driver info: chromedriver=2.12.301324 (de8ab311bc9374d0ade71f7c167bad61848c7c48),platform=Linux 3.13.0-44-generic x86_64) (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 32 milliseconds
For documentation on this error, please visit: http://seleniumhq.org/exceptions/stale_element_reference.html
Build info: version: '2.39.0', revision: 'ff23eac', time: '2013-12-16 16:11:15'
System info: host: 'mauritz-vbox', ip: '10.249.123.47', os.name: 'Linux', os.arch: 'amd64', os.version: '3.13.0-44-generic', java.version: '1.6.0_33'
Session ID: 5255d00491949bc8aa6e2d41f54e00e7
Driver info: org.openqa.selenium.chrome.ChromeDriver
Capabilities [{platform=LINUX, acceptSslCerts=true, javascriptEnabled=true, browserName=chrome, chrome={userDataDir=/tmp/.com.google.Chrome.aX9znn}, rotatable=false, locationContextEnabled=true, mobileEmulationEnabled=false, version=38.0.2125.122, takesHeapSnapshot=true, cssSelectorsEnabled=true, databaseEnabled=false, handlesAlerts=true, browserConnectionEnabled=false, nativeEvents=true, webStorageEnabled=true, applicationCacheEnabled=false, takesScreenshot=true}] at (eval 72) line 4.
```