### PR TITLE
Rename upload file to fixed value

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2462,9 +2462,11 @@ sub upload_file {
     my $ret = $self->_execute_command( $res, $params );
 
     #WORKAROUND: Since this is undocumented selenium functionality, work around a bug.
-    my ($drive, $path, $file) = File::Spec::Functions::splitpath($ret);
-    if ($file ne $filename) {
-        $ret = File::Spec::Functions::catpath($drive,$path,$filename);
+    if (defined($raw_content)) {
+        my ($drive, $path, $file) = File::Spec::Functions::splitpath($ret);
+        if ($file ne $filename) {
+            $ret = File::Spec::Functions::catpath($drive,$path,$filename);
+        }
     }
 
     return $ret;
@@ -2474,7 +2476,7 @@ sub _prepare_file {
     my ($self,$filename) = @_;
     if ( not -r $filename ) { die "upload_file: no such file: $filename"; }
     my $string = "";    # buffer
-    zip $filename => \$string
+    zip $filename => \$string, Name => 'UploadFile'
       or die "zip failed: $ZipError\n";    # compress the file into string
     require MIME::Base64;
 

--- a/t/01-driver-jamadam.t
+++ b/t/01-driver-jamadam.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+
+use JSON;
+use Test::More;
+use LWP::UserAgent;
+use Test::LWP::UserAgent;
+use IO::Socket::INET;
+use Selenium::Remote::Driver;
+use Selenium::Remote::Mock::Commands;
+use Selenium::Remote::Mock::RemoteConnection;
+
+use FindBin;
+use lib $FindBin::Bin . '/lib';
+use TestHarness;
+use Test::Fatal;
+
+my $harness = TestHarness->new(
+    this_file => $FindBin::Script
+);
+my %selenium_args = %{ $harness->base_caps };
+
+my $driver = Selenium::Remote::Driver->new(%selenium_args);
+my $domain = $harness->domain;
+my $website = $harness->website;
+my $ret;
+
+my $chrome;
+eval { $chrome = Selenium::Remote::Driver->new(
+    %selenium_args,
+    browser_name => 'firefox'
+); };
+
+use File::Basename 'dirname';
+use File::Spec::Functions qw{catfile};
+
+UPLOAD: {
+    my $file = catfile(dirname(__FILE__), '01-driver-jamadam.t');
+    my $file2 = catfile(dirname(__FILE__), '../Changes');
+    eval {
+        $driver->upload_file($file);
+    };
+    is $@, '';
+    eval {
+        $driver->upload_file($file2);
+    };
+    is $@, '';
+}
+
+done_testing;


### PR DESCRIPTION
Hi. I'd like to propose a change on upload_file method behavior.

I encountered a selenium server side error by following code.

    $sel->upload_file('./1/2/3.txt'); # /path/to/temp1/1/2/3.txt
    $sel->upload_file('../1/2/3.txt'); # ERROR by remote server

To traverse the directory, I'm doing as follows on my script.

    my $bytes;
    zip catdir(dirname(__FILE__), '../test-images/small.jpg')
                                    => \$bytes, Name => 'UploadFile';
    $sel->upload_file('UploadFile', encode_base64($bytes)); # /path/to/temp1/UploadFile

To ease the use case, I assume it's sensible to preset the file name on remote machine.
And the argument is only an identifier for local machine file.

By applying this patch, the method come to behave as follows.
Remote server seems to automatically creates unique temp directory names.

    $sel->upload_file('./1/2/3.txt'); # /path/to/temp1/UploadFile.txt
    $sel->upload_file('../1/2/3.txt'); # /path/to/temp2/UploadFile.txt

I haven't been figured out how to test it with mock-recording.

UPDATED: UploadFile.txt => Upload
UPDATED: prefix => preset