### PR TITLE
Extending with Moose causes Deep recursion in Moo::HandleMoose

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -285,8 +285,7 @@ has 'browser_name' => (
 );
 
 has 'base_url' => (
-    is      => 'rw',
-    lazy    => 1,
+    is      => 'lazy',
     coerce  => sub {
         my $base_url = shift;
         $base_url =~ s|/$||;
@@ -413,14 +412,12 @@ has 'firefox_profile' => (
 );
 
 has 'desired_capabilities' => (
-    is        => 'rw',
-    lazy      => 1,
+    is        => 'lazy',
     predicate => 'has_desired_capabilities'
 );
 
 has 'inner_window_size' => (
-    is        => 'rw',
-    lazy      => 1,
+    is        => 'lazy',
     predicate => 1,
     coerce    => sub {
         my $size = shift;


### PR DESCRIPTION
Moose version 2.1210
Selenium::Remote::Driver version 0.2101

```perl
package Extended::Driver;
use Moose;
extends 'Selenium::Remote::Driver';
1;
```
Result:
<pre>
Deep recursion on subroutine "Moo::HandleMoose::FakeMetaClass::isa" at /home/michael/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Devel/StackTrace.pm line 80.
Deep recursion on subroutine "Moo::HandleMoose::inject_real_metaclass_for" at /home/michael/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Moo/HandleMoose/FakeMetaClass.pm line 17.
<pre>
