### PR TITLE
Non-standard utf8 characters break requests

### DIFF
--- a/lib/Selenium/Remote/RemoteConnection.pm
+++ b/lib/Selenium/Remote/RemoteConnection.pm
@@ -93,7 +93,7 @@ sub request {
     if ((defined $params) && $params ne '') {
         my $json = JSON->new;
         $json->allow_blessed;
-        $content = $json->allow_nonref->utf8->encode($params);
+        $content = $json->allow_nonref->encode($params);
     }
 
     print "REQ: $method, $url, $content\n" if $self->debug;

--- a/t/Finders.t
+++ b/t/Finders.t
@@ -15,36 +15,47 @@ my $harness = TestHarness->new(
 my %selenium_args = %{ $harness->base_caps };
 
 my $driver = Selenium::Remote::Driver->new(%selenium_args);
-$driver->get('http://danielgempesaw.com/Selenium-Remote-Driver/xhtmlTest.html');
 
-# This depends explicitly on the page we're visiting (xhtmlTest.html),
-my %finders = (
-    class => 'navigation',
-    class_name => 'navigation',
-    css => 'html',
-    id => 'linkId',
-    link => 'this goes to the same place',
-    link_text => 'this goes to the same place',
-    name => 'windowOne',
-    partial_link_text => 'this goes to the same',
-    tag_name => 'html',
-    xpath => '//html'
-);
+NO_CROAK_FINDERS: {
+    $driver->get('http://127.0.0.1:63636/xhtmlTest.html');
 
-foreach my $by (keys %finders) {
-    my $locator = $finders{$by};
-    my $method = 'find_element_by_' . $by;
+    # This depends explicitly on the page we're visiting (xhtmlTest.html),
+    my %finders = (
+        class => 'navigation',
+        class_name => 'navigation',
+        css => 'html',
+        id => 'linkId',
+        link => 'this goes to the same place',
+        link_text => 'this goes to the same place',
+        name => 'windowOne',
+        partial_link_text => 'this goes to the same',
+        tag_name => 'html',
+        xpath => '//html'
+    );
 
-    ok($driver->can($method), $method . ':  installed properly');
-    my $elem = $driver->$method($locator);
-    ok($elem, $method . ': finds an element properly');
-    ok($elem->isa('Selenium::Remote::WebElement'), $method . ': element is a WebElement');
-    {
-        # Briefly suppress warning output for prettier tests
-        my $warned = 0;
-        local $SIG{__WARN__} = sub { $warned++ };
-        ok(!$driver->$method('missing') , $method . ': does not croak on unavailable elements');
-        ok($warned, $method . ': unavailable elements throw a warning');
+    foreach my $by (keys %finders) {
+        my $locator = $finders{$by};
+        my $method = 'find_element_by_' . $by;
+
+        ok($driver->can($method), $method . ':  installed properly');
+        my $elem = $driver->$method($locator);
+        ok($elem, $method . ': finds an element properly');
+        ok($elem->isa('Selenium::Remote::WebElement'), $method . ': element is a WebElement');
+        {
+            # Briefly suppress warning output for prettier tests
+            my $warned = 0;
+            local $SIG{__WARN__} = sub { $warned++ };
+            ok(!$driver->$method('missing') , $method . ': does not croak on unavailable elements');
+            ok($warned, $method . ': unavailable elements throw a warning');
+        }
     }
 }
+
+ODD_ENCODING: {
+    $driver->get('http://127.0.0.1:63636/index.html');
+    my $umlaut = $driver->find_element('äëïöü', 'id');
+    ok( $umlaut->isa('Selenium::Remote::WebElement'),
+    'we can find elements with non-standard encoding' );
+}
+
 done_testing;

--- a/t/www/index.html
+++ b/t/www/index.html
@@ -69,5 +69,7 @@ document.write(" and with document.write again");
   <span id="displayed">I am displayed.</span>
   <span id="hidden" style="display: none;">I am hidden.</span>
 </div>
+
+<div id="äëïöü"></div>
 </body>
 </html>


### PR DESCRIPTION
When using find_element() to find an element with non-standard (a-z,A-Z,0-9,...) characters like è or ü or anything else in the name the webdriver does not find the element although it is present on the page because of converting issues in RemoteConnection.pm:67:
$content = $json->allow_nonref->utf8->encode($params);

I already searched the CPAN doc of JSON but could not find out what the encode method excpects as encoding or what it does with different ones:/