### PR TITLE
(in cleanup) Can't call method "get_params" on an undefined value

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -486,13 +486,11 @@ sub new_from_caps {
     return $self->new(%args);
 }
 
-before 'DEMOLISH' => sub {
+sub DEMOLISH {
     my ($self) = @_;
     return if $$ != $self->pid;
     $self->quit() if ( $self->auto_close && defined $self->session_id );
-};
-
-sub DEMOLISH {}
+}
 
 # This is an internal method used the Driver & is not supposed to be used by
 # end user. This method is used by Driver to set up all the parameters

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -486,11 +486,13 @@ sub new_from_caps {
     return $self->new(%args);
 }
 
-sub DEMOLISH {
+before 'DEMOLISH' => sub {
     my ($self) = @_;
     return if $$ != $self->pid;
     $self->quit() if ( $self->auto_close && defined $self->session_id );
-}
+};
+
+sub DEMOLISH {}
 
 # This is an internal method used the Driver & is not supposed to be used by
 # end user. This method is used by Driver to set up all the parameters

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -487,8 +487,9 @@ sub new_from_caps {
 }
 
 sub DEMOLISH {
-    my ($self) = @_;
+    my ($self, $in_global_destruction) = @_;
     return if $$ != $self->pid;
+    return if $in_global_destruction;
     $self->quit() if ( $self->auto_close && defined $self->session_id );
 }
 
@@ -986,7 +987,12 @@ sub close {
 =head2 quit
 
  Description:
-    Delete the session & close open browsers.
+    Delete the session & close open browsers. We will try to call this
+    on our down when we get DEMOLISHed, but in the event that we are
+    only demolished during global destruction, we will not be able to
+    close the browser. For your own unattended and/or complicated tests,
+    we recommend explicitly calling quit to make sure you're not leaving
+    orphan browsers around.
 
  Usage:
     $driver->quit();


### PR DESCRIPTION
Guys,
When my Selenium test scripts fail I see the following message:
```
Error while executing command: clickElement: An element command could not be completed because the element is not visible on the page.: Element is not currently visible and so may not be interacted with
Build info: version: '2.45.0', revision: '5017cb8', time: '2015-02-26 23:59:50'
System info: host: 'TechWires-MacBook-Pro-15.local', ip: '192.168.22.35', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.7.5', java.version: '1.8.0_25'
Driver info: driver.version: unknown at (eval 58) line 17.
	(in cleanup) Can't call method "get_params" on an undefined value at C:/Strawberry/perl/site/lib/Selenium/Remote/Driver.pm line 269 during global destruction.
```
I'm pretty sure the "get_params" method was OK before I updated the Driver to the latest version.

Cpanm shows:
```
Selenium::Remote::Driver is up to date (0.24).
```
