### PR TITLE
Fix find no elt ok

### DIFF
--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -325,9 +325,9 @@ sub element_value_is {
     return $self->_find_element_with_action($method,@_);
 }
 
-=head2 $twd->click_element_ok($search_target [,$desc]);
+=head2 $twd->click_element_ok($search_target [,$finder ,$desc]);
 
-    $twd->click_element_ok($search_target [,$desc]);
+    $twd->click_element_ok($search_target [,$finder ,$desc]);
 
 Find an element and then click on it.
 
@@ -339,9 +339,9 @@ sub click_element_ok {
     return $self->_find_element_with_action($method,@_);
 }
 
-=head2 $twd->clear_element_ok($search_target [,$desc]);
+=head2 $twd->clear_element_ok($search_target [,$finder ,$desc]);
 
-    $twd->clear_element_ok($search_target [,$desc]);
+    $twd->clear_element_ok($search_target [,$finder ,$desc]);
 
 Find an element and then clear on it.
 
@@ -353,9 +353,9 @@ sub clear_element_ok {
     return $self->_find_element_with_action($method,@_);
 }
 
-=head2 $twd->is_element_displayed_ok($search_target [,$desc]);
+=head2 $twd->is_element_displayed_ok($search_target [,$finder ,$desc]);
 
-    $twd->is_element_displayed_ok($search_target [,$desc]);
+    $twd->is_element_displayed_ok($search_target [,$finder ,$desc]);
 
 Find an element and check to confirm that it is displayed. (visible)
 
@@ -367,9 +367,9 @@ sub is_element_displayed_ok {
     return $self->_find_element_with_action($method,@_);
 }
 
-=head2 $twd->is_element_enabled_ok($search_target [,$desc]);
+=head2 $twd->is_element_enabled_ok($search_target [,$finder ,$desc]);
 
-    $twd->is_element_enabled_ok($search_target [,$desc]);
+    $twd->is_element_enabled_ok($search_target [,$finder ,$desc]);
 
 Find an element and check to confirm that it is enabled.
 
@@ -402,8 +402,7 @@ See there for more details on the format for C<find_element_ok()>.
 
 Returns true if C<$search_target> is I<not> found on the page. C<$search_target>
 is passed to L<Selenium::Remote::Driver/find_element> using a finder or the
-C<default_finder> if none passed.See there for more details on the format. 
-for C<find_no_element_ok()>.
+C<default_finder> if none passed. See there for more details on the format for C<find_no_element_ok()>.
 
 =cut
 

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -239,6 +239,7 @@ more documentation, see the related test methods in L<Selenium::Remote::Driver>
 
     click_ok
     double_click_ok
+
 =cut
 
 
@@ -385,7 +386,7 @@ sub is_element_enabled_ok {
 
    $twd->find_element_ok( $search_target [,$finder, $desc ] );
 
-Returns true if C<$search_target> is successfully found on the page. L<$search_target>
+Returns true if C<$search_target> is successfully found on the page. C<$search_target>
 is passed to L<Selenium::Remote::Driver/find_element> using a finder or the C<default_finder>
 if none passed.
 See there for more details on the format for C<find_element_ok()>.
@@ -399,7 +400,7 @@ See there for more details on the format for C<find_element_ok()>.
 
    $twd->find_no_element_ok( $search_target [,$finder, $desc ] );
 
-Returns true if C<$search_target> is I<not> found on the page. L<$search_target>
+Returns true if C<$search_target> is I<not> found on the page. C<$search_target>
 is passed to L<Selenium::Remote::Driver/find_element> using a finder or the
 C<default_finder> if none passed.See there for more details on the format. 
 for C<find_no_element_ok()>.

--- a/lib/Test/Selenium/Remote/Role/DoesTesting.pm
+++ b/lib/Test/Selenium/Remote/Role/DoesTesting.pm
@@ -5,6 +5,7 @@ package Test::Selenium::Remote::Role::DoesTesting;
 use Moo::Role;
 use Test::Builder;
 use Try::Tiny;
+use Scalar::Util 'blessed';
 use List::MoreUtils qw/any/;
 use namespace::clean;
 
@@ -96,11 +97,19 @@ sub _check_ok {
         }
     };
 
+
     my $default_test_name = $method;
     $default_test_name .= "'" . join("' ", @r_args) . "'"
         if $num_of_args > 0;
 
     my $test_name = pop @args // $default_test_name;
+
+    # case when find_no_element found an element, we should croak
+    if ($real_method eq 'find_no_element') { 
+        if (blessed($rv) && $rv->isa('Selenium::Remote::WebElement')) { 
+            $self->croak($test_name);
+        }
+    }
     return $self->ok( $rv, $test_name);
 }
 

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -110,6 +110,7 @@ ok( exception { $successful_driver->find_child_element_ok({id => 1200}) }, 'find
 # find no element ok test
 
 $successful_driver->find_no_element_ok('notq','xpath','find_no_element_ok works');
+ok(exception { $successful_driver->find_no_element_ok('q','xpath','find_no_element_ok works') }, 'find no element dies when an element is found');
 
 # body and content function family
 $successful_driver->content_like( qr/matches/, 'content_like works');


### PR DESCRIPTION
`find_no_element_ok` had a nasty bug where, when an element was actually found by `find_element`, the test was not failing. This is now fixed (added a test to check that too). 
On top of that, I made the documentation modifications asked in #211. 
@gempesaw please have a look :+1: 