### PR TITLE
Make time mock not required for installation

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -42,8 +42,8 @@ on 'test' => sub {
   requires "Test::Fatal" => "0";
   requires "Test::LWP::UserAgent" => "0";
   requires "Test::More" => "0";
+  requires "Test::Time" => "0";
   requires "Test::Warn" => "0";
-  requires "Time::Mock" => "0";
   requires "lib" => "0";
 };
 

--- a/t/Waiter.t
+++ b/t/Waiter.t
@@ -5,14 +5,15 @@ use warnings;
 use Test::More;
 use Test::Warn;
 use Test::Fatal;
-use Time::Mock throttle => 100;
+use Test::Time;
 use Selenium::Waiter;
 
 SIMPLE_WAIT: {
     my $ret;
-    waits_ok( sub { $ret = wait_until { 1 } }, '<', 5, 'immediately true returns quickly' );
+    waits_ok( sub { $ret = wait_until { 1 } }, '<', 2, 'immediately true returns quickly' );
     ok($ret == 1, 'return value for a true wait_until is passed up');
-    waits_ok( sub { $ret = wait_until { 0 } }, '>', 25, 'never true expires the timeout' );
+
+    waits_ok( sub { $ret = wait_until { 0 } }, '==', 30, 'never true expires the timeout' );
     ok($ret eq '', 'return value for a false wait is an empty string');
 }
 


### PR DESCRIPTION
From an email:


> All my work laptops are Windows based computers, so I am stuck with Activestate or Strawberry perl. I tried to install Selenium::Remote:Driver with both cpanm and ppm commands, and both fails due to Time::Mock issue.  Seems like Time::Mock does not support Windows: http://code.activestate.com/ppm/Time-Mock/

> I tried force install commands on cpan, but that didn't work either.  I am not a professional programmer (I am actually a Pharmacist), so I am pretty much stuck right now. Should I try to downgrade a Selenium version and try to manually install?

I'll try to figure out how to either remove it or not make it required for installation, I guess.