### PR TITLE
Changed timeout for starting browser from 10 to 16 sec.

### DIFF
--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -228,7 +228,7 @@ sub _build_binary_mode {
     my $command = $self->_construct_command;
     system($command);
 
-    my $success = wait_until { probe_port($port) } timeout => 10;
+    my $success = wait_until { probe_port($port) } timeout => 16;
     if ($success) {
         return 1;
     }


### PR DESCRIPTION
For Browsers in a small, virtual machine using xvfb starting in 10 seconds not always succeds.
In my case 10 seconds were too short for most tries, while 16 worked good.

I can imagine other users on small or old machines could profit from this, while of course
timeouts are always a decision of tradeoff, consideration and chosing priorities.
So I would understand if this patch wouldn't be merged.