### PR TITLE
milliseconds value passed to java needs to be numeric.

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2748,6 +2748,30 @@ sub delete_local_storage_item {
     return $self->_execute_command($res, $params);
 }
 
+sub _coerce_timeout_ms {
+    my ($ms) = @_;
+
+    if ( not defined $ms ) {
+        my @caller = caller(1);
+        my $subroutine_name = $caller[3];
+
+        croak 'Expecting a timeout in ms';
+    }
+
+    return _coerce_number( $ms );
+}
+
+sub _coerce_number {
+    my ($maybe_number) = @_;
+
+    if ( Scalar::Util::looks_like_number( $maybe_number )) {
+        return $maybe_number + 0;
+    }
+    else {
+        croak "Expecting a number, not: $maybe_number";
+    }
+}
+
 
 1;
 

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2754,14 +2754,12 @@ sub delete_local_storage_item {
 sub _coerce_timeout_ms {
     my ($ms) = @_;
 
-    if ( not defined $ms ) {
-        my @caller = caller(1);
-        my $subroutine_name = $caller[3];
-
+    if ( defined $ms ) {
+        return _coerce_number( $ms );
+    }
+    else {
         croak 'Expecting a timeout in ms';
     }
-
-    return _coerce_number( $ms );
 }
 
 sub _coerce_number {

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -968,9 +968,11 @@ sub get_capabilities {
 
 sub set_timeout {
     my ( $self, $type, $ms ) = @_;
-    if ( not defined $type or not defined $ms ) {
-        croak "Expecting type & timeout in ms";
+    if ( not defined $type  ) {
+        croak "Expecting type";
     }
+    $ms = _coerce_timeout_ms( $ms );
+
     my $res = { 'command' => 'setTimeout' };
     my $params = { 'type' => $type, 'ms' => $ms };
     return $self->_execute_command( $res, $params );
@@ -994,9 +996,8 @@ sub set_timeout {
 
 sub set_async_script_timeout {
     my ( $self, $ms ) = @_;
-    if ( not defined $ms ) {
-        croak "Expecting timeout in ms";
-    }
+    $ms = _coerce_timeout_ms( $ms );
+
     my $res    = { 'command' => 'setAsyncScriptTimeout' };
     my $params = { 'ms'      => $ms };
     return $self->_execute_command( $res, $params );
@@ -1026,6 +1027,8 @@ sub set_async_script_timeout {
 
 sub set_implicit_wait_timeout {
     my ( $self, $ms ) = @_;
+    $ms = _coerce_timeout_ms( $ms );
+
     my $res    = { 'command' => 'setImplicitWaitTimeout' };
     my $params = { 'ms'      => $ms };
     return $self->_execute_command( $res, $params );

--- a/t/01-driver.t
+++ b/t/01-driver.t
@@ -554,4 +554,22 @@ QUIT: {
     ok((not defined $driver->{'session_id'}), 'Killed the remote session');
 }
 
+COERCION: {
+    my $string = 'string';
+    like( exception { Selenium::Remote::Driver::_coerce_number( $string ) },
+          qr/Expecting a number/,
+          'Can coerce numbers'
+      );
+
+    like( exception { Selenium::Remote::Driver::_coerce_timeout_ms() },
+          qr/Expecting a timeout/,
+          'Can coerce missing timeouts'
+      );
+
+    like( exception { Selenium::Remote::Driver::_coerce_timeout_ms( $string ) },
+          qr/Expecting a number/,
+          'Can coerce non-numeric timeouts'
+      );
+}
+
 done_testing;

--- a/t/01-driver.t
+++ b/t/01-driver.t
@@ -195,10 +195,22 @@ WINDOW: {
 
     $ret = $driver->get_page_source();
     ok($ret =~ m/^<html/i, 'Received page source');
-    eval {$driver->set_implicit_wait_timeout(20001);};
-    ok(!$@,"Set implicit wait timeout");
+
+    # Using a string instead of an int exercises the
+    # _coerce_timeout_ms functionality
+    eval {$driver->set_implicit_wait_timeout("20001");};
+    ok(!$@,"Set implicit wait timeout with string");
     eval {$driver->set_implicit_wait_timeout(0);};
-    ok(!$@,"Reset implicit wait timeout");
+    ok(!$@,"Reset implicit wait timeout with integer");
+
+    my $invalid_ms = 'invalid timeout ms';
+    ok( exception{ $driver->set_timeout('script', $invalid_ms) },
+        'Coerce ms arguments for set_timeout' );
+    ok( exception{ $driver->set_async_script_timeout( $invalid_ms ) },
+        'Coerce ms arguments for set_async_script_timeout' );
+    ok( exception{ $driver->set_implicit_wait_timeout( $invalid_ms ) },
+        'Coerce ms arguments for set_implicit_wait_timeout' );
+
     $ret = $driver->get("$website/frameset.html");
     $ret = $driver->switch_to_frame('second');
 


### PR DESCRIPTION
    'Error while executing command: setImplicitWaitTimeout: An unknown server-side error occurred
    while processing the command.: java.lang.String cannot be cast to java.lang.Number at /opt/perl
    /5.22/lib/site_perl/5.22.0/Selenium/Remote/Driver.pm line 300.

The problem shows up when dealing with test plans stored in YAML and read via YAML::XS, something in Load is treating the timeout numeric as string-y (maybe leaving the SV with both numeric and string set to true?) which freaks out Java. Due to the perl debugger thinking the value is numeric, I'm guessing that the issue is with bindings rather than YAML::XS.

Short version of the fix is adding zero on the way into *timeout* subs, for example:

    sub set_implicit_wait_timeout
    {
        my ( $self, $ms ) = @_;
        my $res    = { 'command' => 'setImplicitWaitTimeout' };
        my $params = { 'ms'      => 0 + $ms };
        return $self->_execute_command( $res, $params );
    }

works.

That or dealing with the Java bindings to prefer the numeric portion of an SV passed in where the
Java sub's args indicate a number.

The problem is that there isn't any way to tell the value is un-usable on the Perly side of things (and walking every struct with "looks_like_number $_ && $_ += 0" seems a bit extreme...). 

Kwikhak fix (without touching Java bindings): <https://gist.github.com/d5c83722135835c80b48.git>

Thanks

Background:

I've added a thin wrapper around Selenium::Remote::Driver for testing websites. Includes things like "find_and_click", "input_and_enter" that include an "ok" of the field is found and then [hey!] clicks it with another "ok" or adds the final KEY->{ enter } value. The wrapper object is scalar-ref with $$wrapper = $driver.

Most of the work passes through an AUTOLOAD that calls $$wrapper->$method( @_ ).

Using the code you provided in your talk at YAPC as a test I start with:

    $s_test->prepare_test
    (
        [ get => 'http://www.google.com'        ],
        [ set_implicit_wait_timeout   => 50_000 ],
    );

Which calls $$s_test->set_implicit_wait_timeout( 50000 ).
Works perfectly.

Acquiring the same set of values via YAML::XS, however, repeatably fails.
For example this blows u 100% of the time:

    #!/bin/env perl
    ########################################################################
    # housekeeping
    ########################################################################
    use v5.22;

    use YAML::XS    qw( Load );

    use Selenium::Remote::Driver;

    ########################################################################
    # package variables
    ########################################################################

    my $struct  
    = do
    {
        local $/;
        Load <DATA>
    };

    my $method  = shift @$struct;

    my $driver  = Selenium::Remote::Driver->new
    ( 
            qw( default_finder  link_text )
    );

    $driver->$method( @$struct );

    # this is not a module
    0
    __END__

    ---
        - set_implicit_wait_timeout
        - 50000

Looking into the Driver.pm code (lines reported are off by a few due to $DB::single inserts):

    534:        my ( $self, $ms ) = @_;
      DB<1> n
    Selenium::Remote::Driver::set_implicit_wait_timeout(/opt/perl/5.22/lib/site_perl/5.22.0/Selenium/Remote/Driver.pm:535):
    535:        my $res    = { 'command' => 'setImplicitWaitTimeout' };
      DB<1> p $ms
    50000
      DB<2> x $ms
    0  50000

Looks as if Perl thinks the value is numeric (no quotes).
Yet, the value blows up in java.
Adding zero in Perl fixes the problem:

    sub set_implicit_wait_timeout
    {
        # 0 + keeps java happy with explicitly numeric value.
        my ( $self, $ms ) = @_;
        my $res    = { 'command' => 'setImplicitWaitTimeout' };
        my $params = { 'ms'      => 0 + $ms };
        return $self->_execute_command( $res, $params );
    }


