### PR TITLE
Replace "#!.*perl" with "#!/bin/env perl" where necessary, remove elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the following should start up Firefox for you:
 #### Locally
 
 ```perl
-#! /usr/bin/perl
+#!/bin/env perl
 
 use strict;
 use warnings;

--- a/driver-example.pl
+++ b/driver-example.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/bin/env perl
 use Selenium::Remote::Driver;
 use Test::More tests=>4;
 

--- a/lib/Selenium/Remote/Mock/RemoteConnection.pm
+++ b/lib/Selenium/Remote/Mock/RemoteConnection.pm
@@ -191,7 +191,7 @@ mock responses to specific functions
 
 =head2 Record interactions
 
-    #!perl
+    #!/bin/env perl
     use strict;
     use warnings;
     use Selenium::Remote::Driver;

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,4 +1,3 @@
-#! /usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/01-driver.t
+++ b/t/01-driver.t
@@ -1,3 +1,4 @@
+
 use strict;
 use warnings;
 

--- a/t/02-webelement.t
+++ b/t/02-webelement.t
@@ -1,3 +1,4 @@
+
 use strict;
 use warnings;
 

--- a/t/03-spec-coverage.t
+++ b/t/03-spec-coverage.t
@@ -1,4 +1,3 @@
-#!perl
 
 use strict;
 use warnings;

--- a/t/04-commands-implemented.t
+++ b/t/04-commands-implemented.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+
 use strict;
 use warnings;
 

--- a/t/10-switch-to-window.t
+++ b/t/10-switch-to-window.t
@@ -1,6 +1,7 @@
+
+use 5.010;
 use strict;
 use warnings;
-use 5.010;
 
 use Test::More;
 use Test::Selenium::Remote::Driver;

--- a/t/11-action-chains.t
+++ b/t/11-action-chains.t
@@ -1,3 +1,4 @@
+
 use strict;
 use warnings;
 

--- a/t/CanStartBinary.t
+++ b/t/CanStartBinary.t
@@ -1,4 +1,3 @@
-#! /usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/Finders.t
+++ b/t/Finders.t
@@ -1,4 +1,3 @@
-#! /usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/Firefox-Profile.t
+++ b/t/Firefox-Profile.t
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/Remote-Connection.t
+++ b/t/Remote-Connection.t
@@ -1,4 +1,3 @@
-#! /usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/Test-Selenium-Remote-Driver-google.t
+++ b/t/Test-Selenium-Remote-Driver-google.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use Test::More;

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+
 use Test::More;
 use Test::Fatal;
 use Test::Selenium::Remote::Driver;

--- a/t/Test-Selenium-Remote-WebElement.t
+++ b/t/Test-Selenium-Remote-WebElement.t
@@ -1,4 +1,4 @@
-#!perl
+
 use Test::More;
 use Selenium::Remote::Mock::Commands;
 use Selenium::Remote::Mock::RemoteConnection;

--- a/t/Waiter.t
+++ b/t/Waiter.t
@@ -1,4 +1,3 @@
-#! /usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/bin/record.pl
+++ b/t/bin/record.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/bin/env perl
 
 use strict;
 use warnings;

--- a/t/convenience.t
+++ b/t/convenience.t
@@ -1,4 +1,3 @@
-#! /usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/error.t
+++ b/t/error.t
@@ -1,4 +1,3 @@
-#! /usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,4 +1,3 @@
-#!perl -T
 
 use strict;
 use warnings;


### PR DESCRIPTION
POD, README, few executables that need it all have "#!/bin/env perl", test files all begin with a blank line.
