### PR TITLE
proxyAutoconfigUrl should support local file URLs also

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -151,7 +151,7 @@ you please.
                 pac        - Proxy autoconfiguration from a URL,
                 autodetect - proxy autodetection, probably with WPAD,
                 system     - Use system settings
-            'proxyAutoconfigUrl' - <string> - REQUIRED if proxyType is 'pac', ignored otherwise. Expected format: http://hostname.com:1234/pacfile.
+            'proxyAutoconfigUrl' - <string> - REQUIRED if proxyType is 'pac', ignored otherwise. Expected format: http://hostname.com:1234/pacfile or file:///path/to/pacfile
             'ftpProxy'           - <string> - OPTIONAL, ignored if proxyType is not 'manual'. Expected format: hostname.com:1234
             'httpProxy'          - <string> - OPTIONAL, ignored if proxyType is not 'manual'. Expected format: hostname.com:1234
             'sslProxy'           - <string> - OPTIONAL, ignored if proxyType is not 'manual'. Expected format: hostname.com:1234
@@ -446,12 +446,22 @@ has 'proxy' => (
     is     => 'rw',
     coerce => sub {
         my $proxy = $_[0];
-        if ( $proxy->{proxyType} eq 'pac' ) {
+        if ( $proxy->{proxyType} =~ /^pac$/i ) {
             if ( not defined $proxy->{proxyAutoconfigUrl} ) {
                 croak "proxyAutoconfigUrl not provided\n";
             }
-            elsif ( not( $proxy->{proxyAutoconfigUrl} =~ /^http/g ) ) {
-                croak "proxyAutoconfigUrl should be of format http://";
+            elsif ( not( $proxy->{proxyAutoconfigUrl} =~ /^(http|file)/g ) ) {
+                croak "proxyAutoconfigUrl should be of format http:// or file://";
+            }
+
+            if ( $proxy->{proxyAutoconfigUrl} =~ /^file/ ) {
+                my $pac_url = $proxy->{proxyAutoconfigUrl};
+                my $file = $pac_url;
+                $file =~ s{^file://}{};
+
+                if (! -e $file) {
+                    warn "proxyAutoConfigUrl file does not exist: '$pac_url'";
+                }
             }
         }
         $proxy;

--- a/t/01-driver-pac.t
+++ b/t/01-driver-pac.t
@@ -1,0 +1,90 @@
+#! /usr/bin/perl
+
+use strict;
+use warnings;
+use JSON;
+use Selenium::Remote::Driver;
+use Test::More;
+use Test::Fatal;
+use Test::LWP::UserAgent;
+
+my $croaking_tests = [
+    {
+        name => 'no PAC url',
+        proxy => {
+            proxyType => 'pac',
+        },
+        pattern => qr/not provided/,
+    },
+    {
+        name => 'PAC url is not http or file',
+        proxy => {
+            proxyType => 'pac',
+            proxyAutoconfigUrl => ''
+        },
+        pattern => qr{of format http:// or file://}
+    }
+];
+
+foreach my $test (@$croaking_tests) {
+    like(
+        exception {
+            Selenium::Remote::Driver->new(proxy => $test->{proxy});
+        },
+        $test->{pattern},
+        'Coercion croaks for case: ' . $test->{name}
+    );
+}
+
+my $passing_tests = [
+    {
+        name => 'PAC url is http',
+        proxy => {
+            proxyType => 'pac',
+            proxyAutoconfigUrl => 'http://pac.file'
+        }
+    },
+    {
+        name => 'PAC url is file',
+        proxy => {
+            proxyType => 'pac',
+            proxyAutoconfigUrl => 'file://' . __FILE__
+        }
+    }
+];
+
+my $tua = mock_simple_webdriver_server();
+foreach my $test (@$passing_tests) {
+    is(
+        exception {
+            Selenium::Remote::Driver->new(
+                proxy => $test->{proxy},
+                ua => $tua
+            );
+        },
+        undef,
+        'Coercion passes for case: ' . $test->{name}
+    );
+}
+
+sub mock_simple_webdriver_server {
+    my $tua = Test::LWP::UserAgent->new;
+    $tua->map_response(qr/status/, HTTP::Response->new(200, 'OK'));
+    $tua->map_response(
+        qr/session/,
+        HTTP::Response->new(
+            204,
+            'OK',
+            ['Content-Type' => 'application/json'],
+            to_json({
+                cmd_return => {},
+                cmd_status => 'OK',
+                sessionId => '123123123'
+            })
+        )
+    );
+
+    return $tua;
+}
+
+done_testing;


### PR DESCRIPTION
In Selenium/Remote/Driver.pm, only "http" URL is allowed for proxyAutoConfigURL.
We need this to work for file URLs also (e.g., file://c/bin/test.pac)
