### PR TITLE
content_like dies on mismatch without error_handler

### DIFF
--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -482,7 +482,7 @@ sub content_like {
     if ( not ref $regex eq 'ARRAY' ) {
         $desc = qq{Content is like "$regex"} if ( not defined $desc );
         $ret = like_string( $content, $regex, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $regex");
         }
         return $ret;
@@ -491,7 +491,7 @@ sub content_like {
         for my $re (@$regex) {
             $desc = qq{Content is like "$re"} if ( not defined $desc );
             $ret = like_string( $content, $re, $desc );
-            if ( !$ret ) {
+			if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $re");
             }
         }
@@ -524,7 +524,7 @@ sub content_unlike {
     if ( not ref $regex eq 'ARRAY' ) {
         $desc = qq{Content is unlike "$regex"} if ( not defined $desc );
         $ret = unlike_string( $content, $regex, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $regex");
         }
     }
@@ -532,7 +532,7 @@ sub content_unlike {
         for my $re (@$regex) {
             $desc = qq{Content is unlike "$re"} if ( not defined $desc );
             $ret = unlike_string( $content, $re, $desc );
-            if ( !$ret ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $re");
             }
         }
@@ -569,7 +569,7 @@ sub body_text_like {
     if ( not ref $regex eq 'ARRAY' ) {
         $desc = qq{Text is like "$regex"} if ( not defined $desc );
         $ret = like_string( $text, $regex, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $regex");
         }
         return $ret;
@@ -578,7 +578,7 @@ sub body_text_like {
         for my $re (@$regex) {
             $desc = qq{Text is like "$re"} if ( not defined $desc );
             $ret = like_string( $text, $re, $desc );
-            if ( !$ret ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $re");
             }
         }
@@ -615,7 +615,7 @@ sub body_text_unlike {
     if ( not ref $regex eq 'ARRAY' ) {
         $desc = qq{Text is unlike "$regex"} if ( not defined $desc );
         $ret = unlike_string( $text, $regex, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $regex");
         }
         return $ret;
@@ -625,7 +625,7 @@ sub body_text_unlike {
         for my $re (@$regex) {
             $desc = qq{Text is unlike "$re"} if ( not defined $desc );
             $ret = unlike_string( $text, $re, $desc );
-            if ( !$ret ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $re");
             }
         }
@@ -661,7 +661,7 @@ sub content_contains {
     if ( not ref $str eq 'ARRAY' ) {
         $desc = qq{Content contains "$str"} if ( not defined $desc );
         $ret = contains_string( $content, $str, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $str");
         }
         return $ret;
@@ -671,7 +671,7 @@ sub content_contains {
             $desc = qq{Content contains "$s"} if ( not defined $desc );
             $ret = contains_string( $content, $s, $desc );
 
-            if ( !$ret ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $s");
             }
         }
@@ -705,7 +705,7 @@ sub content_lacks {
     if ( not ref $str eq 'ARRAY' ) {
         $desc = qq{Content lacks "$str"} if ( not defined $desc );
         $ret = lacks_string( $content, $str, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $str");
         }
         return $ret;
@@ -714,7 +714,7 @@ sub content_lacks {
         for my $s (@$str) {
             $desc = qq{Content lacks "$s"} if ( not defined $desc );
             $ret = lacks_string( $content, $s, $desc );
-            if ( !$ret ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $s");
             }
         }
@@ -751,7 +751,7 @@ sub body_text_contains {
     if ( not ref $str eq 'ARRAY' ) {
         $desc = qq{Text contains "$str"} if ( not defined $desc );
         $ret = contains_string( $text, $str, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $str");
         }
         return $ret;
@@ -760,7 +760,7 @@ sub body_text_contains {
         for my $s (@$str) {
             $desc = qq{Text contains "$s"} if ( not defined $desc );
             $ret = contains_string( $text, $s, $desc );
-            if ( !$ret ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $s");
             }
         }
@@ -797,7 +797,7 @@ sub body_text_lacks {
     if ( not ref $str eq 'ARRAY' ) {
         $desc = qq{Text lacks "$str"} if ( not defined $desc );
         $ret = lacks_string( $text, $str, $desc );
-        if ( !$ret ) {
+        if ( !$ret && $self->has_error_handler ) {
             $self->error_handler->($self,"Failed to find $str");
         }
         return $ret;
@@ -806,7 +806,7 @@ sub body_text_lacks {
         for my $s (@$str) {
             $desc = qq{Text lacks "$s"} if ( not defined $desc );
             $ret = lacks_string( $text, $s, $desc );
-            if ( !$ret ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $s");
             }
         }

--- a/lib/Test/Selenium/Remote/Driver.pm
+++ b/lib/Test/Selenium/Remote/Driver.pm
@@ -491,7 +491,7 @@ sub content_like {
         for my $re (@$regex) {
             $desc = qq{Content is like "$re"} if ( not defined $desc );
             $ret = like_string( $content, $re, $desc );
-			if ( !$ret && $self->has_error_handler ) {
+            if ( !$ret && $self->has_error_handler ) {
                 $self->error_handler->($self,"Failed to find $re");
             }
         }

--- a/t/Test-Selenium-Remote-Driver.t
+++ b/t/Test-Selenium-Remote-Driver.t
@@ -94,7 +94,6 @@ my $successful_driver =
     remote_conn => Selenium::Remote::Mock::RemoteConnection->new( spec => $spec, mock_cmds => $mock_commands ),
     commands => $mock_commands,
 );
-$successful_driver->error_handler(sub { my ($self,$msg) = @_; croak "Got message: $msg";});
 
 # find element ok tests
 $successful_driver->find_element_ok('q','find_element_ok works');
@@ -137,6 +136,40 @@ $successful_driver->clear_element_ok('q','element is cleared ok');
 $successful_driver->is_element_enabled_ok('p','class','element is enabled');
 $successful_driver->is_element_displayed_ok('q','element is displayed');
 
+test_out('not ok 1 - Content is ok', 'ok 2 - No error checking content');
+ok(!exception { $successful_driver->content_like( qr/nomatch/, 'Content is ok') }, 'No error checking content');
+test_test(title => "Can fail 'content_like'",skip_err => 1);
+
+test_out('not ok 1 - Content is ok', 'ok 2 - No error checking content');
+ok(!exception { $successful_driver->content_unlike(qr/matches/, 'Content is ok') }, 'No error checking content');
+test_test(title => "Can fail 'content_unlike'",skip_err => 1);
+
+test_out('not ok 1 - Content is ok', 'ok 2 - No error checking content');
+ok(!exception { $successful_driver->content_contains('blah', 'Content is ok') }, 'No error checking content');
+test_test(title => "Can fail 'content_contains'",skip_err => 1);
+
+test_out('not ok 1 - Content is ok', 'ok 2 - No error checking content');
+ok(!exception { $successful_driver->content_lacks('matches', 'Content is ok') }, 'No error checking content');
+test_test(title => "Error handler works with 'content_lacks'",skip_err => 1);
+
+test_out('not ok 1 - Body is ok', 'ok 2 - No error checking body text');
+ok(!exception { $successful_driver->body_text_like( qr/nomatch/, 'Body is ok') }, 'No error checking body text');
+test_test(title => "Error handler works with 'body_text_like'",skip_err => 1);
+
+test_out('not ok 1 - Body is ok', 'ok 2 - No error checking body text');
+ok(!exception { $successful_driver->body_text_unlike(qr/matches/, 'Body is ok') }, 'No error checking body text');
+test_test(title => "Error handler works with 'body_text_unlike'",skip_err => 1);
+
+test_out('not ok 1 - Body is ok', 'ok 2 - No error checking body text');
+ok(!exception { $successful_driver->body_text_contains('nomatch', 'Body is ok') }, 'No error checking body text');
+test_test(title => "Error handler works with 'body_text_contains'",skip_err => 1);
+
+# This one is just a little tricky: 'match' is a match, so body_text_lacks should report failure, and the opposite for 'bar'
+test_out('not ok 1 - Body is ok','ok 2 - Body is ok', 'ok 3 - No error checking body text');
+ok(!exception { $successful_driver->body_text_lacks(['match','bar'], 'Body is ok') }, 'No error checking body text');
+test_test(title => "Error handler works with 'body_text_lacks'",skip_err => 1);
+
+$successful_driver->error_handler(sub { my ($self,$msg) = @_; croak "Got message: $msg";});
 test_out('not ok 1 - Content is ok'."\n".'ok 2 - Error callback triggered');
 like(exception { $successful_driver->content_like( qr/nomatch/, 'Content is ok') },qr/^Got message/,'Error callback triggered');
 test_test(title => "Error handler works with 'content_like'",skip_err => 1);


### PR DESCRIPTION
Something like the following:
```my $driver = Test::Selenium::Remote::Driver->new;
    $driver->content_like(qr/I am not found/);```
causes an error unless `error_handler` is set.

Pull request coming shortly: the new tests, I think, make it pretty clear.