### PR TITLE
Switch to enable Marionette in Firefox

### DIFF
--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -255,10 +255,10 @@ sub _build_binary_mode {
     my $port = $self->port + 0;
     return if $port == 4444;
 
-    my $marionette_port = $self->marionette_enabled ?
-    $self->marionette_port : 0;
-
     if ($self->isa('Selenium::Firefox')) {
+        my $marionette_port = $self->marionette_enabled ?
+        $self->marionette_port : 0;
+
         my @args = ($port, $marionette_port);
 
         if ($self->has_firefox_profile) {

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -121,6 +121,20 @@ has '+port' => (
     }
 );
 
+has 'marionette_port' => (
+    is => 'lazy',
+    builder => sub {
+        my ($self) = @_;
+
+        if ($self->isa('Selenium::Firefox') && $self->marionette_enabled) {
+            return find_open_port_above($self->marionette_binary_port);
+        }
+        else {
+            return;
+        }
+    }
+);
+
 =attr startup_timeout
 
 Optional: you can modify how long we will wait for the binary to start
@@ -240,6 +254,9 @@ sub _build_binary_mode {
     # Either the user asked for 4444, or we couldn't find an open port
     my $port = $self->port + 0;
     return if $port == 4444;
+
+    my $marionette_port = $self->marionette_enabled ?
+    $self->marionette_port : 0;
 
     if ($self->isa('Selenium::Firefox')) {
         my @args = ($port);

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -259,7 +259,7 @@ sub _build_binary_mode {
     $self->marionette_port : 0;
 
     if ($self->isa('Selenium::Firefox')) {
-        my @args = ($port);
+        my @args = ($port, $marionette_port);
 
         if ($self->has_firefox_profile) {
             push @args, $self->firefox_profile;

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -88,10 +88,31 @@ has '+wd_context_prefix' => (
     default => sub { '/hub' }
 );
 
+=attr marionette_binary_port
+
+Optional: specify the port that we should bind Marionette to. If you don't
+specify anything, we'll default to the driver's default port. Since
+there's no a priori guarantee that this will be an open port, this is
+_not_ necessarily the port that we end up using - if the port here is
+already bound, we'll search above it until we find an open one.
+
+See L<Selenium::CanStartBinary/port> for more details, and
+L<Selenium::Remote::Driver/port> after instantiation to see what the
+actual port turned out to be.
+
+=cut
+
 has 'marionette_binary_port' => (
     is => 'lazy',
     default => sub { 2828 }
 );
+
+=attr marionette_binary_port
+
+Optional: specify whether Marionette should be enabled or not. The
+firefox binary must have been built with this funtionality.
+
+=cut
 
 has 'marionette_enabled' => (
     is  => 'lazy',

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -8,6 +8,7 @@ extends 'Selenium::Remote::Driver';
 =head1 SYNOPSIS
 
     my $driver = Selenium::Firefox->new;
+    my $driver = Selenium::Firefox->new( marionette_enabled => 1 );
 
 =head1 DESCRIPTION
 

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -75,13 +75,27 @@ has '_binary_args' => (
     builder => sub {
         my ($self) = @_;
 
-        return ' -no-remote';
+        my $args = ' -no-remote';
+        if( $self->marionette_enabled ) {
+            $args .= ' -marionette';
+        }
+        return $args;
     }
 );
 
 has '+wd_context_prefix' => (
     is => 'ro',
     default => sub { '/hub' }
+);
+
+has 'marionette_binary_port' => (
+    is => 'lazy',
+    default => sub { 2828 }
+);
+
+has 'marionette_enabled' => (
+    is  => 'lazy',
+    default => 0
 );
 
 with 'Selenium::CanStartBinary';

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -107,7 +107,7 @@ has 'marionette_binary_port' => (
     default => sub { 2828 }
 );
 
-=attr marionette_binary_port
+=attr marionette_enabled
 
 Optional: specify whether Marionette should be enabled or not. The
 firefox binary must have been built with this funtionality.

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -90,8 +90,8 @@ has '+wd_context_prefix' => (
 
 =attr marionette_binary_port
 
-Optional: specify the port that we should bind Marionette to. If you don't
-specify anything, we'll default to the driver's default port. Since
+Optional: specify the port that we should bind marionette to. If you don't
+specify anything, we'll default to the marionette's default port. Since
 there's no a priori guarantee that this will be an open port, this is
 _not_ necessarily the port that we end up using - if the port here is
 already bound, we'll search above it until we find an open one.
@@ -99,6 +99,11 @@ already bound, we'll search above it until we find an open one.
 See L<Selenium::CanStartBinary/port> for more details, and
 L<Selenium::Remote::Driver/port> after instantiation to see what the
 actual port turned out to be.
+
+    Selenium::Firefox->new(
+        marionette_enabled     => 1,
+        marionette_binary_port => 12345,
+    );
 
 =cut
 
@@ -109,8 +114,26 @@ has 'marionette_binary_port' => (
 
 =attr marionette_enabled
 
-Optional: specify whether Marionette should be enabled or not. The
-firefox binary must have been built with this funtionality.
+Optional: specify whether L<marionette|https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette>
+should be enabled or not. If you enable the marionette_enabled flag,
+Firefox is launched with marionette server listening to
+C<marionette_binary_port>.
+
+The firefox binary must have been built with this funtionality and it's
+available in L<all recent Firefox binaries|https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Builds>.
+
+Note: L<Selenium::Remote::Driver> does not yet provide a marionette
+client. It's up to the user to use a client or a marionette-to-webdriver
+proxy to communicate with the marionette server.
+
+    Selenium::Firefox->new( marionette_enabled => 1 );
+
+and Firefox will have 2 ports open. One for webdriver and one
+for marionette:
+
+    netstat -tlp | grep firefox
+    tcp    0    0    localhost:9090    *:*    LISTEN    23456/firefox
+    tcp    0    0    localhost:2828    *:*    LISTEN    23456/firefox
 
 =cut
 

--- a/lib/Selenium/Firefox/Binary.pm
+++ b/lib/Selenium/Firefox/Binary.pm
@@ -64,10 +64,11 @@ sub firefox_path {
 # the end of this function.
 my $profile;
 sub setup_firefox_binary_env {
-    my ($port, $caller_profile) = @_;
+    my ($port, $marionette_port, $caller_profile) = @_;
 
     $profile = $caller_profile || Selenium::Firefox::Profile->new;
     $profile->add_webdriver($port);
+    $profile->add_marionette($marionette_port);
 
     $ENV{'XRE_PROFILE_PATH'} = $profile->_layout_on_disk;
     $ENV{'MOZ_NO_REMOTE'} = '1';             # able to launch multiple instances

--- a/lib/Selenium/Firefox/Profile.pm
+++ b/lib/Selenium/Firefox/Profile.pm
@@ -217,6 +217,19 @@ sub add_webdriver {
     $self->set_preference('webdriver_firefox_port', $port);
 }
 
+=method add_marionette
+
+Primarily for internal use, configure Marionette to the
+current Firefox profile.
+
+=cut
+
+sub add_marionette {
+    my ($self, $port) = @_;
+    return if !$port;
+    $self->set_preference('marionette.defaultPrefs.port', $port);
+}
+
 sub _encode {
     my $self = shift;
 

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -144,6 +144,7 @@ you please.
         'javascript'           - <boolean>  - whether javascript should be supported
         'accept_ssl_certs'     - <boolean>  - whether SSL certs should be accepted, default is true.
         'firefox_profile'      - Profile    - Use Selenium::Firefox::Profile to create a Firefox profile for the browser to use
+        'marionette_enabled'   - <boolean>  - whether Firefox should enable Marionette. default if false
         'proxy'                - HASH       - Proxy configuration with the following keys:
             'proxyType' - <string> - REQUIRED, Possible values are:
                 direct     - A direct connection - no proxy in use,

--- a/t/CanStartBinary.t
+++ b/t/CanStartBinary.t
@@ -75,6 +75,12 @@ FIREFOX: {
         my $firefox = Selenium::Firefox->new;
         isnt( $firefox->port, 4444, 'firefox can start up its own binary');
         ok( Selenium::CanStartBinary::probe_port( $firefox->port ), 'the firefox binary is listening on its port');
+
+        my $firefox_marionette = Selenium::Firefox->new(
+            marionette_enabled => 1
+        );
+        isnt( $firefox->port, 4444, 'firefox can start up its own binary');
+        ok( Selenium::CanStartBinary::probe_port( $firefox_marionette->marionette_port ), 'the firefox binary with marionette enabled is listening on its marionette port');
     }
 }
 


### PR DESCRIPTION
Hi

This patch adds a switch when launching Firefox, to setup and enable the Marionette server (all latest Firefox binary already come with it built in). The default Marionette port is used, or if already used a higher available one is used.

```
use Selenium::Firefox;
my $driver = Selenium::Firefox->new( marionette_enabled => 1 );
```

A Marionette client (or the wires proxy server) is still needed in order to communicate with the browser's Marionette server (this patch doesn't add support for the Marionette protocol). However, this is still useful as Firefox's configuration lives in one place.

Hope this is useful for general purpose. Happy to discuss any changes if needed.

Regards
Vangelis