### PR TITLE
add compatibility with marionette (geckodriver) for firefox 48

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Selenium::Remote::Driver
-
-[![Build Status](https://travis-ci.org/gempesaw/Selenium-Remote-Driver.svg?branch=master)](https://travis-ci.org/gempesaw/Selenium-Remote-Driver)
+# Selenium::Remote::Driver [![Build Status](https://travis-ci.org/gempesaw/Selenium-Remote-Driver.svg?branch=master)](https://travis-ci.org/gempesaw/Selenium-Remote-Driver)
 
 [Selenium WebDriver][wd] is a test tool that allows you to write
 automated web application UI tests in any programming language against
@@ -8,11 +6,7 @@ any HTTP website using any mainstream JavaScript-enabled browser. This
 module is a Perl implementation of the client for the Webdriver
 [JSONWireProtocol that Selenium provides.][jsonwire]
 
-This module sends commands directly to the server using HTTP. Using
-this module together with the Selenium Server, you can automatically
-control any supported browser.
-
-[wd]: https://code.google.com/p/selenium/
+[wd]: http://www.seleniumhq.org/
 [jsonwire]: https://code.google.com/p/selenium/wiki/JsonWireProtocol
 [standalone]: http://selenium-release.storage.googleapis.com/index.html
 
@@ -24,26 +18,34 @@ It's probably easiest to use the `cpanm` or `CPAN` commands:
 $ cpanm Selenium::Remote::Driver
 ```
 
-If you want to install from this repository, you have a few options;
-see the [installation docs][] for more details.
+If you want to install from this repository, see the
+[installation docs][] for more details.
 
 [installation docs]: /INSTALL.md
 
 ## Usage
 
-You can either use this module with the standalone java server, or use
-it to directly start the webdriver binaries for you. Note that the
-latter option does _not_ require the JRE/JDK to be installed, nor does
-it require the selenium standalone server (despite the name of the
-main module!).
+You can use this module to directly start the webdriver binaries in
+your `$PATH` (after having [downloaded the driver servers][dl]). This
+method does not require the JRE/JDK to be installed, nor does it
+require the standalone server jar, despite the name of the module.
+
+You can also use this module with the `selenium-standalone-server.jar`
+to let it handle browser start up for you, and also manage Remote
+connections where the server jar is not running on the same machine as
+your test script is executing.
+
+[dl]: #download-servers
 
 ### with a standalone server
 
-Download the standalone server and have it running on port 4444:
+Download the [standalone server][] and have it running on port 4444:
 
     $ java -jar selenium-server-standalone-X.XX.X.jar
 
 Then the following should start up Firefox for you:
+
+[standalone server]: http://selenium-release.storage.googleapis.com/index.html
 
 #### Locally
 
@@ -105,19 +107,27 @@ useful [example snippets][ex].
 [ex]:
 https://github.com/gempesaw/Selenium-Remote-Driver/wiki/Example-Snippets
 
-### no standalone server
+### [no standalone server](#download-servers)
 
-- _Firefox_: simply have the browser installed in the normal place
-for your OS.
+- _Firefox 48 & newer_: install the Firefox browser, download
+  [geckodriver][gd] and put it in your `$PATH`. If the Firefox browser
+  binary is not in the default place for your OS and we cannot locate
+  it via `which`, you may have to specify the binary location during
+  startup.
+
+- _Firefox 47 & older_: install the Firefox browser in the default
+  place for your OS. If the Firefox browser binary is not in the
+  default place for your OS, you may have to specify the binary
+  location during startup.
 
 - _Chrome_: install the Chrome browser, [download Chromedriver][dcd]
-and get `chromedriver` in your `$PATH`:
+  and get `chromedriver` in your `$PATH`
 
 - _PhantomJS_: install the PhantomJS binary and get `phantomjs` in
   your `$PATH`
 
-As long as the proper binary is available in your path, you should be
-able to do the following:
+When the browser(s) are installed and you have the appropriate binary
+in your path, you should be able to do the following:
 
 ```perl
 my $firefox = Selenium::Firefox->new;
@@ -131,7 +141,8 @@ $ghost->get('http://www.google.com');
 ```
 
 Note that you can also pass a `binary` argument to any of the above
-classes to manually specify what binary to start:
+classes to manually specify what binary to start. Note that this
+`binary` refers to the driver server, _not_ the browser executable.
 
 ```perl
 my $chrome = Selenium::Chrome->new(binary => '~/Downloads/chromedriver');
@@ -140,6 +151,7 @@ my $chrome = Selenium::Chrome->new(binary => '~/Downloads/chromedriver');
 See the pod for the different modules for more details.
 
 [dcd]: https://sites.google.com/a/chromium.org/chromedriver/downloads
+[gd]: https://github.com/mozilla/geckodriver/releases
 
 ## Selenium IDE Plugin
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,33 @@ You can use this module to directly start the webdriver servers, after
 [downloading the appropriate ones][dl] and putting the servers in your
 `$PATH`. This method does not require the JRE/JDK to be installed, nor
 does it require the standalone server jar, despite the name of the
-module.
+module. In this case, you'll want to use the appropriate class for
+driver construction: either [Selenium::Chrome][],
+[Selenium::Firefox][], [Selenium::PhantomJS][], or
+[Selenium::InternetExplorer][].
 
 You can also use this module with the `selenium-standalone-server.jar`
 to let it handle browser start up for you, and also manage Remote
 connections where the server jar is not running on the same machine as
-your test script is executing.
+your test script is executing. The main class for this method is
+[Selenium::Remote::Driver][].
 
+Regardless of which method you use to construct your browser object,
+all of the classes use the functions listed in the S::R::Driver POD
+documentation, so interacting with the browser, the page, and its
+elements would be the same.
+
+[Selenium::Firefox]: https://metacpan.org/pod/Selenium::Firefox
+[Selenium::Chrome]: https://metacpan.org/pod/Selenium::Chrome
+[Selenium::PhantomJS]: https://metacpan.org/pod/Selenium::PhantomJS
+[Selenium::InternetExplorer]: https://metacpan.org/pod/Selenium::InternetExplorer
+[Selenium::Remote::Driver]: https://metacpan.org/pod/Selenium::Remote::Driver
 [dl]: #no-standalone-server
 
 ### no standalone server
 
 - _Firefox 48 & newer_: install the Firefox browser, download
-  [geckodriver][gd] and put it in your `$PATH`. If the Firefox browser
+  [geckodriver][gd] and [put it in your `$PATH`][fxpath]. If the Firefox browser
   binary is not in the default place for your OS and we cannot locate
   it via `which`, you may have to specify the binary location during
   startup.
@@ -52,10 +66,11 @@ your test script is executing.
   location during startup.
 
 - _Chrome_: install the Chrome browser, [download Chromedriver][dcd]
-  and get `chromedriver` in your `$PATH`
+  and get `chromedriver` in your `$PATH`.
 
 - _PhantomJS_: install the PhantomJS binary and get `phantomjs` in
-  your `$PATH`
+  your `$PATH`. The driver for PhantomJS, Ghostdriver, is bundled with
+  PhantomJS.
 
 When the browser(s) are installed and you have the appropriate binary
 in your path, you should be able to do the following:
@@ -82,6 +97,7 @@ my $chrome = Selenium::Chrome->new(binary => '~/Downloads/chromedriver');
 See the pod for the different modules for more details.
 
 [dcd]: https://sites.google.com/a/chromium.org/chromedriver/downloads
+[fxpath]: https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver#Add_executable_to_system_path
 [gd]: https://github.com/mozilla/geckodriver/releases
 
 ### with a standalone server
@@ -90,7 +106,9 @@ Download the [standalone server][] and have it running on port 4444:
 
     $ java -jar selenium-server-standalone-X.XX.X.jar
 
-Then the following should start up Firefox for you:
+As before, have the browsers themselves installed on your machine, and
+download the appropriate binary server, passing its location to the
+server jar during startup.
 
 [standalone server]: http://selenium-release.storage.googleapis.com/index.html
 

--- a/README.md
+++ b/README.md
@@ -25,17 +25,64 @@ If you want to install from this repository, see the
 
 ## Usage
 
-You can use this module to directly start the webdriver binaries in
-your `$PATH` (after having [downloaded the driver servers][dl]). This
-method does not require the JRE/JDK to be installed, nor does it
-require the standalone server jar, despite the name of the module.
+You can use this module to directly start the webdriver servers, after
+[downloading the appropriate ones][dl] and putting the servers in your
+`$PATH`. This method does not require the JRE/JDK to be installed, nor
+does it require the standalone server jar, despite the name of the
+module.
 
 You can also use this module with the `selenium-standalone-server.jar`
 to let it handle browser start up for you, and also manage Remote
 connections where the server jar is not running on the same machine as
 your test script is executing.
 
-[dl]: #download-servers
+[dl]: #no-standalone-server
+
+### no standalone server
+
+- _Firefox 48 & newer_: install the Firefox browser, download
+  [geckodriver][gd] and put it in your `$PATH`. If the Firefox browser
+  binary is not in the default place for your OS and we cannot locate
+  it via `which`, you may have to specify the binary location during
+  startup.
+
+- _Firefox 47 & older_: install the Firefox browser in the default
+  place for your OS. If the Firefox browser binary is not in the
+  default place for your OS, you may have to specify the binary
+  location during startup.
+
+- _Chrome_: install the Chrome browser, [download Chromedriver][dcd]
+  and get `chromedriver` in your `$PATH`
+
+- _PhantomJS_: install the PhantomJS binary and get `phantomjs` in
+  your `$PATH`
+
+When the browser(s) are installed and you have the appropriate binary
+in your path, you should be able to do the following:
+
+```perl
+my $firefox = Selenium::Firefox->new;
+$firefox->get('http://www.google.com');
+
+my $chrome = Selenium::Chrome->new;
+$chrome->get('http://www.google.com');
+
+my $ghost = Selenium::PhantomJS->new;
+$ghost->get('http://www.google.com');
+```
+
+Note that you can also pass a `binary` argument to any of the above
+classes to manually specify what binary to start. Note that this
+`binary` refers to the driver server, _not_ the browser executable.
+
+```perl
+my $chrome = Selenium::Chrome->new(binary => '~/Downloads/chromedriver');
+```
+
+See the pod for the different modules for more details.
+
+[dcd]: https://sites.google.com/a/chromium.org/chromedriver/downloads
+[gd]: https://github.com/mozilla/geckodriver/releases
 
 ### with a standalone server
 
@@ -107,56 +154,10 @@ useful [example snippets][ex].
 [ex]:
 https://github.com/gempesaw/Selenium-Remote-Driver/wiki/Example-Snippets
 
-### [no standalone server](#download-servers)
-
-- _Firefox 48 & newer_: install the Firefox browser, download
-  [geckodriver][gd] and put it in your `$PATH`. If the Firefox browser
-  binary is not in the default place for your OS and we cannot locate
-  it via `which`, you may have to specify the binary location during
-  startup.
-
-- _Firefox 47 & older_: install the Firefox browser in the default
-  place for your OS. If the Firefox browser binary is not in the
-  default place for your OS, you may have to specify the binary
-  location during startup.
-
-- _Chrome_: install the Chrome browser, [download Chromedriver][dcd]
-  and get `chromedriver` in your `$PATH`
-
-- _PhantomJS_: install the PhantomJS binary and get `phantomjs` in
-  your `$PATH`
-
-When the browser(s) are installed and you have the appropriate binary
-in your path, you should be able to do the following:
-
-```perl
-my $firefox = Selenium::Firefox->new;
-$firefox->get('http://www.google.com');
-
-my $chrome = Selenium::Chrome->new;
-$chrome->get('http://www.google.com');
-
-my $ghost = Selenium::PhantomJS->new;
-$ghost->get('http://www.google.com');
-```
-
-Note that you can also pass a `binary` argument to any of the above
-classes to manually specify what binary to start. Note that this
-`binary` refers to the driver server, _not_ the browser executable.
-
-```perl
-my $chrome = Selenium::Chrome->new(binary => '~/Downloads/chromedriver');
-```
-
-See the pod for the different modules for more details.
-
-[dcd]: https://sites.google.com/a/chromium.org/chromedriver/downloads
-[gd]: https://github.com/mozilla/geckodriver/releases
-
 ## Selenium IDE Plugin
 
-[ide-plugin.js](./ide-plugin.js) is a Selenium IDE Plugin which allows you to export tests recorded 
-in Selenium IDE to a perl script.
+[ide-plugin.js](./ide-plugin.js) is a Selenium IDE Plugin which allows
+you to export tests recorded in Selenium IDE to a perl script.
 
 ### Installation in Selenium IDE
 

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -248,7 +248,7 @@ has 'window_title' => (
     init_arg => undef,
     builder => sub {
         my ($self) = @_;
-        my (undef, undef, $file) = File::Spec->splitpath( $self->binary );
+        my (undef, undef, $file) = File::Spec->splitpath( $self->_real_binary );
         my $port = $self->port;
 
         return $file . ':' . $port;

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -285,10 +285,13 @@ sub _build_binary_mode {
 
         if ($self->has_firefox_profile) {
             push @args, $self->firefox_profile;
-            $self->clear_firefox_profile;
         }
 
-        setup_firefox_binary_env(@args);
+        my $profile = setup_firefox_binary_env(@args);
+        # For geckodriver, setting env variable XRE_PROFILE_PATH does
+        # not seem to work anymore. Instead, geckodriver accepts an
+        # encoded firefox profile, so we need to set it on the Driver.
+        $self->firefox_profile($profile);
     }
 
     my $command = $self->_construct_command;

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -171,10 +171,10 @@ has 'marionette_port' => (
         my ($self) = @_;
 
         if ($self->_is_old_ff) {
-            return find_open_port_above($self->marionette_binary_port);
+            return 0;
         }
         else {
-            return;
+            return find_open_port_above($self->marionette_binary_port);
         }
     }
 );
@@ -319,17 +319,13 @@ sub _handle_firefox_setup {
     # This is a no-op for other browsers
     return unless $self->isa('Selenium::Firefox');
 
-    my $marionette_port = $self->_is_old_ff
-      ? 0
-      : $self->marionette_port;
-
     my $user_profile = $self->has_firefox_profile
       ? $self->firefox_profile
       : 0;
 
     my $profile = setup_firefox_binary_env(
         $port,
-        $marionette_port,
+        $self->marionette_port,
         $user_profile
     );
 

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -365,7 +365,7 @@ sub shutdown_windows_binary {
     my ($self) = @_;
 
     if (IS_WIN) {
-        if ($self->isa('Selenium::Firefox')) {
+        if ($self->_is_old_ff) {
             # FIXME: Blech, handle a race condition that kills the
             # driver before it's finished cleaning up its sessions. In
             # particular, when the perl process ends, it wants to

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -277,8 +277,9 @@ sub _build_binary_mode {
     return if $port == 4444;
 
     if ($self->isa('Selenium::Firefox')) {
-        my $marionette_port = $self->marionette_enabled ?
-        $self->marionette_port : 0;
+        my $marionette_port = $self->marionette_enabled
+          ? $self->marionette_port
+          : 0;
 
         my @args = ($port, $marionette_port);
 

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -379,14 +379,7 @@ sub _cmd_prefix {
     my ($self) = @_;
 
     if (IS_WIN) {
-        my $prefix = 'start "' . $self->window_title . '"';
-
-        # Let's minimize the command windows for the drivers that have
-        # separate binaries - but let's not minimize the Firefox
-        # window itself.
-        if (! $self->isa('Selenium::Firefox')) {
-            $prefix .= ' /MIN ';
-        }
+        my $prefix = 'start "' . $self->window_title . '" /MIN';
         return $prefix;
     }
     else {

--- a/lib/Selenium/CanStartBinary/FindBinary.pm
+++ b/lib/Selenium/CanStartBinary/FindBinary.pm
@@ -25,18 +25,6 @@ sub coerce_simple_binary {
     }
 }
 
-sub coerce_firefox_binary {
-    my ($executable) = @_;
-
-    my $manual_binary = _validate_manual_binary($executable);
-    if ($manual_binary) {
-        return $manual_binary;
-    }
-    else {
-        return firefox_path();
-    }
-}
-
 sub _validate_manual_binary {
     my ($executable) = @_;
 

--- a/lib/Selenium/CanStartBinary/FindBinary.pm
+++ b/lib/Selenium/CanStartBinary/FindBinary.pm
@@ -1,7 +1,6 @@
 package Selenium::CanStartBinary::FindBinary;
 
 # ABSTRACT: Coercions for finding webdriver binaries on your system
-use File::Which qw/which/;
 use Cwd qw/abs_path/;
 use File::Which qw/which/;
 use IO::Socket::INET;
@@ -22,6 +21,18 @@ sub coerce_simple_binary {
     }
     else {
         return _naive_find_binary($executable);
+    }
+}
+
+sub coerce_firefox_binary {
+    my ($executable) = @_;
+
+    my $manual_binary = _validate_manual_binary($executable);
+    if ($manual_binary) {
+        return $manual_binary;
+    }
+    else {
+        return firefox_path();
     }
 }
 
@@ -52,7 +63,7 @@ sub _naive_find_binary {
         return $naive_binary;
     }
     else {
-        warn qq(Unable to find the $executable binary in your \$PATH. We'll try falling back to standard Remote Driver);
+        warn qq(Unable to find the $executable binary in your \$PATH.);
         return;
     }
 }

--- a/lib/Selenium/Chrome.pm
+++ b/lib/Selenium/Chrome.pm
@@ -8,6 +8,8 @@ extends 'Selenium::Remote::Driver';
 =head1 SYNOPSIS
 
     my $driver = Selenium::Chrome->new;
+    # when you're done
+    $driver->shutdown_binary;
 
 =head1 DESCRIPTION
 
@@ -98,6 +100,23 @@ up to 20 seconds:
     Selenium::Chrome->new( startup_timeout => 20 );
 
 See L<Selenium::CanStartBinary/startup_timeout> for more information.
+
+=method shutdown_binary
+
+Call this method instead of L<Selenium::Remote::Driver/quit> to ensure
+that the binary executable is also closed, instead of simply closing
+the browser itself. If the browser is still around, it will call
+C<quit> for you. After that, it will try to shutdown the browser
+binary by making a GET to /shutdown and on Windows, it will attempt to
+do a C<taskkill> on the binary CMD window.
+
+    $self->shutdown_binary;
+
+It doesn't take any arguments, and it doesn't return anything.
+
+We do our best to call this when the C<$driver> option goes out of
+scope, but if that happens during global destruction, there's nothing
+we can do.
 
 =cut
 

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -12,9 +12,12 @@ extends 'Selenium::Remote::Driver';
     # greater
     my $driver = Selenium::Firefox->new;
     my $driver = Selenium::Firefox->new( marionette_enabled => 1 );
+    # execute your test as usual
+    $driver->shutdown_binary;
 
     # For Firefox 47 and older, disable marionette:
     my $driver = Selenium::Firefox->new( marionette_enabled => 0 );
+    $driver->shutdown_binary;
 
 =head1 DESCRIPTION
 
@@ -225,6 +228,23 @@ up to 20 seconds:
     Selenium::Firefox->new( startup_timeout => 20 );
 
 See L<Selenium::CanStartBinary/startup_timeout> for more information.
+
+=method shutdown_binary
+
+Call this method instead of L<Selenium::Remote::Driver/quit> to ensure
+that the binary executable is also closed, instead of simply closing
+the browser itself. If the browser is still around, it will call
+C<quit> for you. After that, it will try to shutdown the browser
+binary by making a GET to /shutdown and on Windows, it will attempt to
+do a C<taskkill> on the binary CMD window.
+
+    $self->shutdown_binary;
+
+It doesn't take any arguments, and it doesn't return anything.
+
+We do our best to call this when the C<$driver> option goes out of
+scope, but if that happens during global destruction, there's nothing
+we can do.
 
 =cut
 

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -2,7 +2,7 @@ package Selenium::Firefox;
 
 # ABSTRACT: Use FirefoxDriver without a Selenium server
 use Moo;
-use Selenium::CanStartBinary::FindBinary qw/coerce_simple_binary/;
+use Selenium::CanStartBinary::FindBinary qw/coerce_simple_binary coerce_firefox_binary/;
 extends 'Selenium::Remote::Driver';
 
 =head1 SYNOPSIS
@@ -103,16 +103,19 @@ has '_binary_args' => (
     builder => sub {
         my ($self) = @_;
 
-        my $args = ' --log trace --port ' . $self->port;
         if ( $self->marionette_enabled ) {
+            my $args = ' --log trace --port ' . $self->port;
             $args .= ' --marionette-port ' . $self->marionette_binary_port;
 
             if ( $self->has_firefox_binary ) {
                 $args .= ' --binary ' . $self->firefox_binary;
             }
-        }
 
-        return $args;
+            return $args;
+        }
+        else {
+            return ' -no-remote';
+        }
     }
 );
 
@@ -181,6 +184,7 @@ directly start up.
 
 has 'firefox_binary' => (
     is => 'lazy',
+    coerce => \&coerce_firefox_binary,
     predicate => 1,
     default => sub { '' }
 );

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -121,7 +121,17 @@ has '_binary_args' => (
 
 has '+wd_context_prefix' => (
     is => 'ro',
-    default => sub { '' }
+    default => sub {
+        my ($self) = @_;
+
+        if ($self->marionette_enabled) {
+            return '';
+        }
+        else {
+            return '/hub';
+        }
+
+    }
 );
 
 =attr marionette_binary_port
@@ -186,7 +196,7 @@ has 'firefox_binary' => (
     is => 'lazy',
     coerce => \&coerce_firefox_binary,
     predicate => 1,
-    default => sub { '' }
+    default => sub { 'firefox' }
 );
 
 

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -2,7 +2,7 @@ package Selenium::Firefox;
 
 # ABSTRACT: Use FirefoxDriver without a Selenium server
 use Moo;
-use Selenium::CanStartBinary::FindBinary qw/coerce_firefox_binary/;
+use Selenium::CanStartBinary::FindBinary qw/coerce_simple_binary/;
 extends 'Selenium::Remote::Driver';
 
 =head1 SYNOPSIS
@@ -47,8 +47,8 @@ able to find it, so you may be well served by specifying it yourself.
 
 has 'binary' => (
     is => 'lazy',
-    coerce => \&coerce_firefox_binary,
-    default => sub { 'firefox' },
+    coerce => \&coerce_simple_binary,
+    default => sub { 'geckodriver' },
     predicate => 1
 );
 
@@ -76,9 +76,9 @@ has '_binary_args' => (
     builder => sub {
         my ($self) = @_;
 
-        my $args = ' -no-remote';
+        my $args = ' --log trace --port ' . $self->port;
         if( $self->marionette_enabled ) {
-            $args .= ' -marionette';
+            $args .= ' --marionette-port ' . $self->marionette_binary_port;
         }
         return $args;
     }
@@ -86,7 +86,7 @@ has '_binary_args' => (
 
 has '+wd_context_prefix' => (
     is => 'ro',
-    default => sub { '/hub' }
+    default => sub { '' }
 );
 
 =attr marionette_binary_port
@@ -140,7 +140,7 @@ for marionette:
 
 has 'marionette_enabled' => (
     is  => 'lazy',
-    default => 0
+    default => 1
 );
 
 with 'Selenium::CanStartBinary';

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -104,7 +104,7 @@ has '_binary_args' => (
         my ($self) = @_;
 
         if ( $self->marionette_enabled ) {
-            my $args = ' --log trace --port ' . $self->port;
+            my $args = ' --port ' . $self->port;
             $args .= ' --marionette-port ' . $self->marionette_binary_port;
 
             if ( $self->has_firefox_binary ) {

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -77,9 +77,14 @@ has '_binary_args' => (
         my ($self) = @_;
 
         my $args = ' --log trace --port ' . $self->port;
-        if( $self->marionette_enabled ) {
+        if ( $self->marionette_enabled ) {
             $args .= ' --marionette-port ' . $self->marionette_binary_port;
+
+            if ( $self->has_firefox_binary ) {
+                $args .= ' --binary ' . $self->firefox_binary;
+            }
         }
+
         return $args;
     }
 );
@@ -96,10 +101,6 @@ specify anything, we'll default to the marionette's default port. Since
 there's no a priori guarantee that this will be an open port, this is
 _not_ necessarily the port that we end up using - if the port here is
 already bound, we'll search above it until we find an open one.
-
-See L<Selenium::CanStartBinary/port> for more details, and
-L<Selenium::Remote::Driver/port> after instantiation to see what the
-actual port turned out to be.
 
     Selenium::Firefox->new(
         marionette_enabled     => 1,
@@ -139,9 +140,16 @@ for marionette:
 =cut
 
 has 'marionette_enabled' => (
-    is  => 'lazy',
+    is => 'lazy',
     default => 1
 );
+
+has 'firefox_binary' => (
+    is => 'lazy',
+    predicate => 1,
+    default => sub { '' }
+);
+
 
 with 'Selenium::CanStartBinary';
 

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -2,6 +2,7 @@ package Selenium::Firefox;
 
 # ABSTRACT: Use FirefoxDriver without a Selenium server
 use Moo;
+use Selenium::Firefox::Binary qw/firefox_path/;
 use Selenium::CanStartBinary::FindBinary qw/coerce_simple_binary coerce_firefox_binary/;
 extends 'Selenium::Remote::Driver';
 
@@ -108,7 +109,7 @@ has '_binary_args' => (
             $args .= ' --marionette-port ' . $self->marionette_binary_port;
 
             if ( $self->has_firefox_binary ) {
-                $args .= ' --binary ' . $self->firefox_binary;
+                $args .= ' --binary "' . $self->firefox_binary . '"';
             }
 
             return $args;
@@ -193,10 +194,10 @@ directly start up.
 =cut
 
 has 'firefox_binary' => (
-    is => 'lazy',
+    is => 'ro',
     coerce => \&coerce_firefox_binary,
     predicate => 1,
-    default => sub { 'firefox' }
+    builder => 'firefox_path'
 );
 
 

--- a/lib/Selenium/Firefox/Binary.pm
+++ b/lib/Selenium/Firefox/Binary.pm
@@ -70,6 +70,16 @@ sub setup_firefox_binary_env {
     $profile->add_webdriver($port);
     $profile->add_marionette($marionette_port);
 
+    # For non-geckodriver/marionette startup, we instruct Firefox to
+    # use the profile by specifying the appropriate environment
+    # variables for it to hook onto.
+    if (! $marionette_port) {
+        $ENV{'XRE_PROFILE_PATH'} = $profile->_layout_on_disk;
+        $ENV{'MOZ_NO_REMOTE'} = '1'; # able to launch multiple instances
+        $ENV{'MOZ_CRASHREPORTER_DISABLE'} = '1'; # disable breakpad
+        $ENV{'NO_EM_RESTART'} = '1'; # prevent the binary from detaching from the console.log
+    }
+
     return $profile;
 }
 

--- a/lib/Selenium/Firefox/Binary.pm
+++ b/lib/Selenium/Firefox/Binary.pm
@@ -70,10 +70,7 @@ sub setup_firefox_binary_env {
     $profile->add_webdriver($port);
     $profile->add_marionette($marionette_port);
 
-    $ENV{'XRE_PROFILE_PATH'} = $profile->_layout_on_disk;
-    $ENV{'MOZ_NO_REMOTE'} = '1';             # able to launch multiple instances
-    $ENV{'MOZ_CRASHREPORTER_DISABLE'} = '1'; # disable breakpad
-    $ENV{'NO_EM_RESTART'} = '1';             # prevent the binary from detaching from the console.log
+    return $profile;
 }
 
 

--- a/lib/Selenium/Firefox/Binary.pm
+++ b/lib/Selenium/Firefox/Binary.pm
@@ -67,7 +67,7 @@ sub setup_firefox_binary_env {
     my ($port, $marionette_port, $caller_profile) = @_;
 
     $profile = $caller_profile || Selenium::Firefox::Profile->new;
-    $profile->add_webdriver($port);
+    $profile->add_webdriver($port, $marionette_port);
     $profile->add_marionette($marionette_port);
 
     # For non-geckodriver/marionette startup, we instruct Firefox to

--- a/lib/Selenium/Firefox/Profile.pm
+++ b/lib/Selenium/Firefox/Profile.pm
@@ -191,7 +191,7 @@ for a new geckodriver session.
 =cut
 
 sub add_webdriver {
-    my ($self, $port) = @_;
+    my ($self, $port, $is_marionette) = @_;
 
     my $prefs = $self->_load_prefs;
     my $current_user_prefs = $self->{user_prefs};
@@ -202,10 +202,13 @@ sub add_webdriver {
         # mutable loaded prefs
         %{ $current_user_prefs },
         # but the frozen ones cannot be overwritten
-        %{ $prefs->{frozen} }
+        %{ $prefs->{frozen} },
+        'webdriver_firefox_port' => $port
     );
 
-    $self->set_preference('webdriver_firefox_port', $port);
+    if (! $is_marionette) {
+        $self->_add_webdriver_xpi;
+    }
 
     return $self;
 }
@@ -235,11 +238,11 @@ sub _load_prefs {
 
 =method add_webdriver_xpi
 
-Obsolete; primarily for internal use. This adds the fxgoogle .xpi that
-was used for webdriver communication in FF47 and older. For FF48 and
-newer, the old method using an extension to orchestrate the webdriver
+Primarily for internal use. This adds the fxgoogle .xpi that is used
+for webdriver communication in FF47 and older. For FF48 and newer, the
+old method using an extension to orchestrate the webdriver
 communication with the Firefox browser has been obsoleted by the
-introduction of geckodriver aka wires aka Marionette.
+introduction of C<geckodriver>.
 
 =cut
 

--- a/lib/Selenium/Firefox/Profile.pm
+++ b/lib/Selenium/Firefox/Profile.pm
@@ -23,7 +23,7 @@ use XML::Simple;
 You can use this module to create a custom Firefox Profile for your
 Selenium tests. Currently, you can set browser preferences and add
 extensions to the profile before passing it in the constructor for a
-new Selenium::Remote::Driver.
+new L</Selenium::Remote::Driver> or L</Selenium::Firefox>.
 
 =head1 SYNPOSIS
 
@@ -185,16 +185,39 @@ sub add_extension {
 
 =method add_webdriver
 
-Primarily for internal use, we add the webdriver extension to the
-current Firefox profile.
+Primarily for internal use, we set the appropriate firefox preferences
+for a new geckodriver session.
 
 =cut
 
 sub add_webdriver {
     my ($self, $port) = @_;
 
+    my $prefs = $self->_load_prefs;
+    my $current_user_prefs = $self->{user_prefs};
+
+    $self->set_preference(
+        %{ $prefs->{mutable} },
+        # having the user prefs here allows them to overwrite the
+        # mutable loaded prefs
+        %{ $current_user_prefs },
+        # but the frozen ones cannot be overwritten
+        %{ $prefs->{frozen} }
+    );
+
+    $self->set_preference('webdriver_firefox_port', $port);
+
+    return $self;
+}
+
+sub _load_prefs {
+    # The appropriate webdriver preferences are stored in an adjacent
+    # JSON file; it's useful things like disabling default browser
+    # checks and setting an empty single page as the start up tab
+    # configuration. Unfortunately, these change with each version of
+    # webdriver.
+
     my $this_dir = dirname(abs_path(__FILE__));
-    my $webdriver_extension = $this_dir . '/webdriver.xpi';
     my $default_prefs_filename = $this_dir . '/webdriver_prefs.json';
 
     my $json;
@@ -204,17 +227,29 @@ sub add_webdriver {
         $json = <$fh>;
         close ($fh);
     }
-    my $webdriver_prefs = decode_json($json);
-    my $current_user_prefs = $self->{user_prefs};
 
-    $self->set_preference(
-        %{ $webdriver_prefs->{mutable} },
-        %{ $current_user_prefs }
-    );
-    $self->set_preference(%{ $webdriver_prefs->{frozen} });
+    my $prefs = decode_json($json);
+
+    return $prefs;
+}
+
+=method add_webdriver_xpi
+
+Obsolete; primarily for internal use. This adds the fxgoogle .xpi that
+was used for webdriver communication in FF47 and older. For FF48 and
+newer, the old method using an extension to orchestrate the webdriver
+communication with the Firefox browser has been obsoleted by the
+introduction of geckodriver aka wires aka Marionette.
+
+=cut
+
+sub _add_webdriver_xpi {
+    my ($self) = @_;
+
+    my $this_dir = dirname(abs_path(__FILE__));
+    my $webdriver_extension = $this_dir . '/webdriver.xpi';
 
     $self->add_extension($webdriver_extension);
-    $self->set_preference('webdriver_firefox_port', $port);
 }
 
 =method add_marionette

--- a/lib/Selenium/InternetExplorer.pm
+++ b/lib/Selenium/InternetExplorer.pm
@@ -7,6 +7,8 @@ extends 'Selenium::Remote::Driver';
 =head1 SYNOPSIS
 
     my $driver = Selenium::InternetExplorer->new;
+    # when you're done
+    $driver->shutdown_binary;
 
 =cut
 
@@ -19,5 +21,24 @@ has '+platform' => (
     is => 'ro',
     default => sub { 'WINDOWS' }
 );
+
+=method shutdown_binary
+
+Call this method instead of L<Selenium::Remote::Driver/quit> to ensure
+that the binary executable is also closed, instead of simply closing
+the browser itself. If the browser is still around, it will call
+C<quit> for you. After that, it will try to shutdown the browser
+binary by making a GET to /shutdown and on Windows, it will attempt to
+do a C<taskkill> on the binary CMD window.
+
+    $self->shutdown_binary;
+
+It doesn't take any arguments, and it doesn't return anything.
+
+We do our best to call this when the C<$driver> option goes out of
+scope, but if that happens during global destruction, there's nothing
+we can do.
+
+=cut
 
 1;

--- a/lib/Selenium/PhantomJS.pm
+++ b/lib/Selenium/PhantomJS.pm
@@ -8,6 +8,8 @@ extends 'Selenium::Remote::Driver';
 =head1 SYNOPSIS
 
     my $driver = Selenium::PhantomJS->new;
+    # when you're done
+    $driver->shutdown_binary;
 
 =head1 DESCRIPTION
 
@@ -108,6 +110,23 @@ up to 20 seconds:
     Selenium::PhantomJS->new( startup_timeout => 20 );
 
 See L<Selenium::CanStartBinary/startup_timeout> for more information.
+
+=method shutdown_binary
+
+Call this method instead of L<Selenium::Remote::Driver/quit> to ensure
+that the binary executable is also closed, instead of simply closing
+the browser itself. If the browser is still around, it will call
+C<quit> for you. After that, it will try to shutdown the browser
+binary by making a GET to /shutdown and on Windows, it will attempt to
+do a C<taskkill> on the binary CMD window.
+
+    $self->shutdown_binary;
+
+It doesn't take any arguments, and it doesn't return anything.
+
+We do our best to call this when the C<$driver> option goes out of
+scope, but if that happens during global destruction, there's nothing
+we can do.
 
 =cut
 

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -486,8 +486,7 @@ has 'firefox_profile' => (
 
         return $profile;
     },
-    predicate => 'has_firefox_profile',
-    clearer => 1
+    predicate => 'has_firefox_profile'
 );
 
 has 'desired_capabilities' => (
@@ -674,7 +673,12 @@ sub new_desired_session {
 
 sub _request_new_session {
     my ( $self, $args ) = @_;
-    $self->remote_conn->check_status();
+
+    # geckodriver has not yet implemented the GET /status endpoint
+    # https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver/status
+    if (! $self->isa('Selenium::Firefox')) {
+        $self->remote_conn->check_status();
+    }
     # command => 'newSession' to fool the tests of commands implemented
     # TODO: rewrite the testing better, this is so fragile.
     my $resource_new_session = {

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -657,7 +657,7 @@ sub new_session {
     }
 
     if ($args->{desiredCapabilities}->{browserName} =~ /firefox/i
-          && $self->has_firefox_profile) {
+        && $self->has_firefox_profile) {
         $args->{desiredCapabilities}->{firefox_profile} = $self->firefox_profile->_encode;
     }
 

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -486,7 +486,8 @@ has 'firefox_profile' => (
 
         return $profile;
     },
-    predicate => 'has_firefox_profile'
+    predicate => 'has_firefox_profile',
+    clearer => 1
 );
 
 has 'desired_capabilities' => (

--- a/t/CanStartBinary.t
+++ b/t/CanStartBinary.t
@@ -79,24 +79,6 @@ FIREFOX: {
         my $firefox = Selenium::Firefox->new;
         isnt( $firefox->port, 4444, 'firefox can start up its own binary');
         ok( Selenium::CanStartBinary::probe_port( $firefox->port ), 'the firefox binary is listening on its port');
-        $firefox->shutdown_binary;
-
-      PROFILE: {
-            my $encoded = 0;
-            {
-                package FFProfile;
-                use Moo;
-                extends 'Selenium::Firefox::Profile';
-
-                sub _encode { $encoded++ };
-                1;
-            }
-
-            my $p = FFProfile->new;
-            my $firefox_with_profile = Selenium::Firefox->new(firefox_profile => $p);
-            $firefox_with_profile->shutdown_binary;
-            is($encoded, 0, 'Binary firefox does not encode profile unnecessarily');
-        }
 
         my $firefox_marionette = Selenium::Firefox->new(
             marionette_enabled => 1

--- a/t/CanStartBinary.t
+++ b/t/CanStartBinary.t
@@ -79,6 +79,7 @@ FIREFOX: {
         my $firefox = Selenium::Firefox->new;
         isnt( $firefox->port, 4444, 'firefox can start up its own binary');
         ok( Selenium::CanStartBinary::probe_port( $firefox->port ), 'the firefox binary is listening on its port');
+        $firefox->shutdown_binary;
 
         my $firefox_marionette = Selenium::Firefox->new(
             marionette_enabled => 1


### PR DESCRIPTION
FF 48 will no longer support the .xpi addon version for FF startup, in favor of Marionette & geckodriver.. FF 47 currently has a startup bug that prevents it from working with Se 2.53.0. There's a [fix in the works](https://github.com/seleniumhq/selenium/issues/2110#issuecomment-224413609), but by the time 48 rolls around, we'll need to be supporting Marionette anyway.

- [x] add documentation about setting up `geckodriver` for remote SRD
- [x] implement geckodriver startup for binary startup for FF47/48
- [x] update documentation about using geckodriver for binary startup
- [x] add functionality to start FF47 and FF48 from the same codebase
- [x] confirm windows compatibility
- [x] confirm linux compatibility