### PR TITLE
Improve Selenium IDE plugin

### DIFF
--- a/ide-plugin.js
+++ b/ide-plugin.js
@@ -241,7 +241,7 @@ this.options = {
       '                                               browser_name => "${environment}");\n' +
       "\n",
   footer:
-      "${receiver}->quit();\n" +
+      "$driver->quit();\n" +
       "done_testing();\n",
   indent: "0",
   initialIndents: "0"

--- a/ide-plugin.js
+++ b/ide-plugin.js
@@ -234,15 +234,13 @@ this.options = {
       "use strict;\n" +
       "use warnings;\n" +
       "use Selenium::Remote::Driver;\n" +
-      "use Test::More;\n" +
       "\n" +
       'my ${receiver} = Selenium::Remote::Driver->new( remote_server_addr => "${rcHost}",\n' +
       '                                               port => ${rcPort},\n' +
       '                                               browser_name => "${environment}");\n' +
       "\n",
   footer:
-      "$driver->quit();\n" +
-      "done_testing();\n",
+      "$driver->quit();\n",
   indent: "0",
   initialIndents: "0"
 };

--- a/ide-plugin.js
+++ b/ide-plugin.js
@@ -234,13 +234,10 @@ this.options = {
       "use strict;\n" +
       "use warnings;\n" +
       "use Selenium::Remote::Driver;\n" +
+      "use Selenium::Firefox;\n" +
       "\n" +
-      'my ${receiver} = Selenium::Remote::Driver->new( remote_server_addr => "${rcHost}",\n' +
-      '                                               port => ${rcPort},\n' +
-      '                                               browser_name => "${environment}");\n' +
-      "\n",
-  footer:
-      "$driver->quit();\n",
+      'my $driver = Selenium::Firefox->new();\n\n',
+  footer: "\n$driver->quit();\n",
   indent: "0",
   initialIndents: "0"
 };


### PR DESCRIPTION
The perl Code generated by the plugin had to be manually reworked to run correctly.
(Which was still less work than writing the whole test manually)

This makes the plugin output code that directly works.

## Example

### Selenese Code
```html
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
<head profile="http://selenium-ide.openqa.org/profiles/test-case">
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
<link rel="selenium.base" href="http://xkcd.com/" />
<title>xkcd_example</title>
</head>
<body>
<table cellpadding="1" cellspacing="1" border="1">
<thead>
<tr><td rowspan="1" colspan="3">xkcd_example</td></tr>
</thead><tbody>
<tr>
	<td>open</td>
	<td>http://xkcd.com/</td>
	<td></td>
</tr>
<tr>
	<td>clickAndWait</td>
	<td>link=&lt; Prev</td>
	<td></td>
</tr>
<tr>
	<td>clickAndWait</td>
	<td>link=&lt; Prev</td>
	<td></td>
</tr>

</tbody></table>
</body>
</html>
```

### Code generated by Old plugin
```perl
use strict;
use warnings;
use Selenium::Remote::Driver;
use Test::More;

my $driver = Selenium::Remote::Driver->new( remote_server_addr => "localhost",
                                               port => 4444,
                                               browser_name => "firefox");

$driver->get("http://xkcd.com/");
$driver->find_element("< Prev", "link")->click;
$driver->find_element("< Prev", "link")->click;
${receiver}->quit();
done_testing();
```

### Code now generated:
```perl
use strict;
use warnings;
use Selenium::Remote::Driver;
use Selenium::Firefox;

my $driver = Selenium::Firefox->new();

$driver->get("http://xkcd.com/");
$driver->find_element("< Prev", "link")->click;
$driver->find_element("< Prev", "link")->click;

$driver->quit();
```
