### PR TITLE
Add command for Firefox context switching

### DIFF
--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -2,6 +2,7 @@ package Selenium::Firefox;
 
 # ABSTRACT: Use FirefoxDriver without a Selenium server
 use Moo;
+use Carp;
 use Selenium::Firefox::Binary qw/firefox_path/;
 use Selenium::CanStartBinary::FindBinary qw/coerce_simple_binary coerce_firefox_binary/;
 extends 'Selenium::Remote::Driver';
@@ -244,6 +245,65 @@ has 'firefox_binary' => (
     builder => 'firefox_path'
 );
 
+=head2 get_context
+
+ Description:
+    Firefox extension: Retrieve browser's scope (chrome or content).
+    Chrome is a privileged scope where you can access things like the
+    Firefox UI itself. Content scope is where things like webpages live.
+
+ Output:
+    STRING - context {CHROME|CONTENT}
+
+ Usage:
+    print $firefox_driver->get_context();
+
+=cut
+
+sub get_context {
+    my $self = shift;
+
+    if ( $self->_is_old_ff ) {
+        return 0;
+    }
+    my $res = { 'command' => 'getContext' };
+    return $self->_execute_command($res);
+}
+
+=head2 set_context
+
+ Description:
+    Firefox extension: Set browser's scope (chrome or content).
+    Chrome is a privileged scope where you can access things like the
+    Firefox UI itself. Content scope is where things like webpages live.
+
+ Input:
+    Required:
+        <STRING> - context {CHROME|CONTENT}
+
+ Usage:
+    $firefox_driver->set_context( $context );
+
+ Output:
+    BOOLEAN - success or failure
+
+=cut
+
+sub set_context {
+    my ( $self, $context ) = @_;
+
+    if ( $self->_is_old_ff ) {
+        return 0;
+    }
+    if ( not defined $context ) {
+        croak "Expecting context";
+    }
+    if ( $context !~ m/chrome|content/i ) {
+        croak "Expecting context value: chrome or content";
+    }
+    my $res = { 'command' => 'setContext' };
+    return $self->_execute_command( $res, { context => $context } );
+}
 
 with 'Selenium::CanStartBinary';
 

--- a/lib/Selenium/Remote/Commands.pm
+++ b/lib/Selenium/Remote/Commands.pm
@@ -394,6 +394,17 @@ has '_cmds' => (
                 'url'                => 'session/:sessionId/orientation',
                 'no_content_success' => 0
             },
+            # firefox extension
+            'setContext' => {
+                'method'             => 'POST',
+                'url'                => 'session/:sessionId/moz/context',
+                'no_content_success' => 1
+            },
+            'getContext' => {
+                'method'             => 'GET',
+                'url'                => 'session/:sessionId/moz/context',
+                'no_content_success' => 0
+            },
 
             # /session/:sessionId/local_storage
             # /session/:sessionId/local_storage/key/:key

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1188,6 +1188,67 @@ sub get_window_size {
     return $self->_execute_command($res);
 }
 
+=head2 get_context
+
+ Description:
+    Firefox extension: Retrieve browser's scope (chrome or content).
+    Chrome is a privileged scope where you can access things like the
+    Firefox UI itself. Content scope is where things like webpages live.
+
+ Output:
+    STRING - context (values: chrome or content)
+
+ Usage:
+    print $firefox_driver->get_context();
+
+=cut
+
+sub get_context {
+    my $self = shift;
+
+    if ( $self->isa('Selenium::Firefox') && $self->_is_old_ff ) {
+        return 0;
+    }
+    my $res = { 'command' => 'getContext' };
+    return $self->_execute_command($res);
+}
+
+=head2 set_context
+
+ Description:
+    Firefox extension: Set browser's scope (chrome or content).
+    Chrome is a privileged scope where you can access things like the
+    Firefox UI itself. Content scope is where things like webpages live.
+
+ Input:
+    Required:
+        <STRING> - Orientation {CHROME|CONTENT}
+
+ Usage:
+    $firefox_driver->set_context( $context  );
+
+ Output:
+    BOOLEAN - success or failure
+
+=cut
+
+sub set_context {
+    my ( $self, $context ) = @_;
+
+    if ( $self->isa('Selenium::Firefox') && $self->_is_old_ff ) {
+		return 0;
+	}
+
+    if ( not defined $context ) {
+        croak "Expecting context";
+    }
+    if ( $context !~ m/chrome|content/i ) {
+        croak "Expecting context value: chrome or content";
+    }
+    my $res = { 'command' => 'setContext' };
+    return $self->_execute_command( $res, { context => $context } );
+}
+
 =head2 get_window_position
 
  Description:

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -1188,67 +1188,6 @@ sub get_window_size {
     return $self->_execute_command($res);
 }
 
-=head2 get_context
-
- Description:
-    Firefox extension: Retrieve browser's scope (chrome or content).
-    Chrome is a privileged scope where you can access things like the
-    Firefox UI itself. Content scope is where things like webpages live.
-
- Output:
-    STRING - context (values: chrome or content)
-
- Usage:
-    print $firefox_driver->get_context();
-
-=cut
-
-sub get_context {
-    my $self = shift;
-
-    if ( $self->isa('Selenium::Firefox') && $self->_is_old_ff ) {
-        return 0;
-    }
-    my $res = { 'command' => 'getContext' };
-    return $self->_execute_command($res);
-}
-
-=head2 set_context
-
- Description:
-    Firefox extension: Set browser's scope (chrome or content).
-    Chrome is a privileged scope where you can access things like the
-    Firefox UI itself. Content scope is where things like webpages live.
-
- Input:
-    Required:
-        <STRING> - Orientation {CHROME|CONTENT}
-
- Usage:
-    $firefox_driver->set_context( $context  );
-
- Output:
-    BOOLEAN - success or failure
-
-=cut
-
-sub set_context {
-    my ( $self, $context ) = @_;
-
-    if ( $self->isa('Selenium::Firefox') && $self->_is_old_ff ) {
-		return 0;
-	}
-
-    if ( not defined $context ) {
-        croak "Expecting context";
-    }
-    if ( $context !~ m/chrome|content/i ) {
-        croak "Expecting context value: chrome or content";
-    }
-    my $res = { 'command' => 'setContext' };
-    return $self->_execute_command( $res, { context => $context } );
-}
-
 =head2 get_window_position
 
  Description:

--- a/t/04-commands-implemented.t
+++ b/t/04-commands-implemented.t
@@ -14,7 +14,8 @@ for my $command (keys %{$comm}) {
   my $found_command = 0;
   for my $file (
     qw{lib/Selenium/Remote/Driver.pm
-    lib/Selenium/Remote/WebElement.pm}
+    lib/Selenium/Remote/WebElement.pm
+    lib/Selenium/Firefox.pm}
     ) {
     open(my $fh, '<', $file) or die "Couldn't open file $file";
     for (<$fh>) {


### PR DESCRIPTION
geckodriver (Firefox>48) supports the jsonwire extension for context switching: `/session/{sessionId}/moz/context`

Available contexts: chrome and content. _Chrome_ is a privileged scope where you can access things like the Firefox UI itself. _Content_ scope is where things like webpages live.

A few notes/questions:
1. Should the command extension be moved in another module? I added them in `Selenium/Remote/Commands.pm` to demo the change.
2. I guess that we don't want our `@CARP_NOT;` in `Selenium/Firefox.pm`?
3. No tests added yet .If this looks ok overall, I'll add.
