### PR TITLE
Option to probe only for the given port without probing for free ports above it

### DIFF
--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -332,6 +332,9 @@ sub _build_binary_mode {
     # Either the user asked for 4444, or we couldn't find an open port
     my $port = $self->port + 0;
     return if $port == 4444;
+    if( $self->fixed_ports && $port == 0 ){
+        die "fixed port is not free";
+    }
 
     $self->_handle_firefox_setup($port);
 

--- a/lib/Selenium/CanStartBinary.pm
+++ b/lib/Selenium/CanStartBinary.pm
@@ -333,7 +333,7 @@ sub _build_binary_mode {
     my $port = $self->port + 0;
     return if $port == 4444;
     if( $self->fixed_ports && $port == 0 ){
-        die "fixed port is not free";
+        die 'port ' . $self->binary_port . ' is not free and have requested fixed ports';
     }
 
     $self->_handle_firefox_setup($port);

--- a/lib/Selenium/CanStartBinary/ProbePort.pm
+++ b/lib/Selenium/CanStartBinary/ProbePort.pm
@@ -6,7 +6,7 @@ use Selenium::Waiter qw/wait_until/;
 
 require Exporter;
 our @ISA = qw/Exporter/;
-our @EXPORT_OK = qw/find_open_port_above probe_port/;
+our @EXPORT_OK = qw/find_open_port_above find_open_port probe_port/;
 
 sub find_open_port_above {
     my ($port) = @_;
@@ -22,6 +22,12 @@ sub find_open_port_above {
     };
 
     return $free_port;
+}
+
+sub find_open_port {
+    my ($port) = @_;
+
+    probe_port($port) ? return 0 : return $port;
 }
 
 sub probe_port {

--- a/lib/Selenium/Chrome.pm
+++ b/lib/Selenium/Chrome.pm
@@ -118,6 +118,11 @@ We do our best to call this when the C<$driver> option goes out of
 scope, but if that happens during global destruction, there's nothing
 we can do.
 
+=attr fixed_ports
+
+Optional: Throw instead of searching for additional ports; see
+L<Selenium::CanStartBinary/fixed_ports> for more info.
+
 =cut
 
 1;

--- a/lib/Selenium/Firefox.pm
+++ b/lib/Selenium/Firefox.pm
@@ -287,6 +287,11 @@ We do our best to call this when the C<$driver> option goes out of
 scope, but if that happens during global destruction, there's nothing
 we can do.
 
+=attr fixed_ports
+
+Optional: Throw instead of searching for additional ports; see
+L<Selenium::CanStartBinary/fixed_ports> for more info.
+
 =cut
 
 1;

--- a/t/CanStartBinary.t
+++ b/t/CanStartBinary.t
@@ -159,37 +159,43 @@ TIMEOUT: {
 }
 
 FIXED_PORTS: {
-    my $driver;
-    my $port = 50000;
+  SKIP: {
+        my $has_geckodriver = which('geckodriver');
+        skip 'Firefox geckodriver not found in path', 1
+          unless $has_geckodriver;
 
-    my $socket = IO::Socket::INET->new(
-        LocalHost => '127.0.0.1',
-        LocalPort => $port,
-        Proto => 'tcp',
-        Listen => 5,
-    ) or BAIL_OUT("Can't bind tcp port $port: $!");
+        my $firefox;
+        my $port = 50000;
 
-    isa_ok(
-        exception {
+        my $socket = IO::Socket::INET->new(
+            LocalHost => '127.0.0.1',
+            LocalPort => $port,
+            Proto => 'tcp',
+            Listen => 5,
+        ) or BAIL_OUT("Can't bind tcp port $port: $!");
+
+        isa_ok(
+            exception {
+                Selenium::Firefox->new(
+                    binary_port => $port,
+                    fixed_ports => 1,
+                );
+            },
+            qr/port $port is not free and have requested fixed ports/,
+            "Driver failed to be created because input port $port is already occupied and flag fixed_ports is true"
+        );
+
+        $firefox = try {
             Selenium::Firefox->new(
                 binary_port => $port,
-                fixed_ports => 1,
             );
-        },
-        qr/port $port is not free and have requested fixed ports/,
-        "Driver failed to be created because input port $port is already occupied and flag fixed_ports is true"
-    );
+        };
+        my $non_fixed_port = $firefox->port;
+        cmp_ok($non_fixed_port, '>=', $port, "Driver could not acquire already occupied $port and a higer port $non_fixed_port was acquired");
 
-    $driver = try {
-        Selenium::Firefox->new(
-            binary_port => $port,
-        );
-    };
-    my $non_fixed_port = $driver->port;
-    cmp_ok($non_fixed_port, '>=', $port, "Driver could not acquire already occupied $port and a higer port $non_fixed_port was acquired");
-
-    $driver->shutdown_binary();
-    $socket->close();
+        $firefox->shutdown_binary();
+        $socket->close();
+    }
 }
 
 sub is_proper_phantomjs_available {

--- a/t/CanStartBinary.t
+++ b/t/CanStartBinary.t
@@ -158,6 +158,40 @@ TIMEOUT: {
     }
 }
 
+FIXED_PORTS: {
+    my $driver;
+    my $port = 50000;
+
+    my $socket = IO::Socket::INET->new(
+        LocalHost => '127.0.0.1',
+        LocalPort => $port,
+        Proto => 'tcp',
+        Listen => 5,
+    ) or BAIL_OUT("Can't bind tcp port $port: $!");
+
+    isa_ok(
+        exception {
+            Selenium::Firefox->new(
+                binary_port => $port,
+                fixed_ports => 1,
+            );
+        },
+        qr/port $port is not free and have requested fixed ports/,
+        "Driver failed to be created because input port $port is already occupied and flag fixed_ports is true"
+    );
+
+    $driver = try {
+        Selenium::Firefox->new(
+            binary_port => $port,
+        );
+    };
+    my $non_fixed_port = $driver->port;
+    cmp_ok($non_fixed_port, '>=', $port, "Driver could not acquire already occupied $port and a higer port $non_fixed_port was acquired");
+
+    $driver->shutdown_binary();
+    $socket->close();
+}
+
 sub is_proper_phantomjs_available {
     my $ver = `phantomjs --version` // '';
     chomp $ver;


### PR DESCRIPTION
The `fixed_ports` is useful if one wants to ensure that geckodriver and firefox instances will listen to the specified ports, and no other higher ports will be probed and assigned.

Let me know if you find this functionality useful and I'll add a test case.