### PR TITLE
Added documentation on how to run Firefox 47 or earlier on Selenium 3+.

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -229,6 +229,12 @@ you please.
     or
     my $driver = Selenium::Remote::Driver->new('browser_name' => 'firefox',
                                                'platform'     => 'MAC');
+    or (for Firefox 47 or lower on Selenium 3+)
+    my $driver = Selenium::Remote::Driver->new('browser_name' => 'firefox',
+                                               'platform'     => 'MAC',
+                                               'extra_capabilities' => {
+                                                    'marionette' => \\0,
+                                              });
     or
     my $driver = Selenium::Remote::Driver->new('remote_server_addr' => '10.10.1.1',
                                                'port'               => '2222',


### PR DESCRIPTION
It was not obvious to get `Selenium::Remote::Driver` running with Firefox 47 or lower (like 45 ESR) together with Selenium 3, so I wanted to share the documentation for this.

Maybe it would be worth adding a more obvious way in the Selenium::Remote::Driver API to toggle the marionette flag. The unusual `\0` syntax is currently needed because it represents a JSON false value.

At the moment Marionette seems to have serious bugs which prevent older test codebases to run with current Firefoxes, but they plan to fix these issues soon so that old test codebases should run unmodified also with Selenium 3 and recent Firefoxes.