### PR TITLE
Fix typo: send \0 as a JSON false value, not \\0.

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -233,7 +233,7 @@ you please.
     my $driver = Selenium::Remote::Driver->new('browser_name' => 'firefox',
                                                'platform'     => 'MAC',
                                                'extra_capabilities' => {
-                                                    'marionette' => \\0,
+                                                    'marionette' => \0,
                                               });
     or
     my $driver = Selenium::Remote::Driver->new('remote_server_addr' => '10.10.1.1',


### PR DESCRIPTION
Sorry, this slipped in from a setup script where I needed to escape the `\`. What we really need is a reference to 0 (`\0`) as a JSON false representation.