### PR TITLE
Handle absolute paths without adding wd_context_prefix

### DIFF
--- a/lib/Selenium/Remote/RemoteConnection.pm
+++ b/lib/Selenium/Remote/RemoteConnection.pm
@@ -72,6 +72,14 @@ sub request {
     if ($url =~ m/^http/g) {
         $fullurl = $url;
     }
+    elsif ($url =~ m/^\//) {
+        # This is used when we get a 302 Redirect with a Location header.
+        $fullurl =
+           "http://"
+          . $self->remote_server_addr . ":"
+          . $self->port
+          . $url;
+    }
     elsif ($url =~ m/grid/g) {
         $fullurl =
             "http://"


### PR DESCRIPTION
Help resolve Issue #312.
When a redirect happens, it passes a absolute URL path back into the request method. It is an error to add the extra wd_context_prefix that the `else` block does.

This makes the code work much better with Sauce Labs when your account is busy.